### PR TITLE
Fix JSON Parse Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ module.exports = function runSync(options) {
   try {
     return JSON.parse(stdout[stdout.length - 1])
   } catch (err) {
-    return stdout[stdout.length - 1]
+    // This should return undefined and not null to indicate that either the
+    // Lambda function had not output or the output could not be parsed. Both
+    // cases should be rare and are most likely the result of an issue with the
+    // Lambda function.
+    return undefined
   }
 }

--- a/index.js
+++ b/index.js
@@ -53,5 +53,10 @@ module.exports = function runSync(options) {
     throw err
   }
 
-  return JSON.parse(spawnResult.stdout)
+  var stdout = spawnResult.stdout.split('\n')
+  try {
+    return JSON.parse(stdout[stdout.length - 1])
+  } catch (err) {
+    return stdout[stdout.length - 1]
+  }
 }

--- a/index.js
+++ b/index.js
@@ -61,6 +61,6 @@ module.exports = function runSync(options) {
     // Lambda function had not output or the output could not be parsed. Both
     // cases should be rare and are most likely the result of an issue with the
     // Lambda function.
-    return undefined
+    return
   }
 }

--- a/test.js
+++ b/test.js
@@ -81,15 +81,15 @@ resetMock({status: 0, stdout: 'Test\nResult\n{"success":true}'})
 result = dockerLambda()
 result.should.eql({success: true})
 
-// Should return last stdout entry if it's not JSON
+// Should return undefined if last stdout entry cannot be parsed
 resetMock({status: 0, stdout: 'Test\nResult\nsuccess'})
 result = dockerLambda()
-result.should.eql('success')
+result === void 0 // Result is undefined and does not contain `should`
 
-// Should return empty string when the function was successful but there is no stdout
+// Should return undefined when function was successful but there is no stdout
 resetMock({status: 0, stdout: ''})
 result = dockerLambda()
-result.should.eql('')
+result === void 0 // Result is undefined and does not contain `should`
 
 // Should throw error if spawn returns error
 resetMock({error: new Error('Something went wrong')})

--- a/test.js
+++ b/test.js
@@ -76,6 +76,21 @@ resetMock({status: 0, stdout: 'null'})
 result = dockerLambda({returnSpawnResult: true})
 result.should.eql({status: 0, stdout: 'null'})
 
+// Should not fail if stdout contains logging
+resetMock({status: 0, stdout: 'Test\nResult\n{"success":true}'})
+result = dockerLambda()
+result.should.eql({success: true})
+
+// Should return last stdout entry if it's not JSON
+resetMock({status: 0, stdout: 'Test\nResult\nsuccess'})
+result = dockerLambda()
+result.should.eql('success')
+
+// Should return empty string when the function was successful but there is no stdout
+resetMock({status: 0, stdout: ''})
+result = dockerLambda()
+result.should.eql('')
+
 // Should throw error if spawn returns error
 resetMock({error: new Error('Something went wrong')})
 var err

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-require('should')
+var should = require('should')
 require('child_process').spawnSync = mockSpawnSync
 
 var dockerLambda = require('.')
@@ -84,12 +84,12 @@ result.should.eql({success: true})
 // Should return undefined if last stdout entry cannot be parsed
 resetMock({status: 0, stdout: 'Test\nResult\nsuccess'})
 result = dockerLambda()
-result === void 0 // Result is undefined and does not contain `should`
+should.not.exist(result)
 
 // Should return undefined when function was successful but there is no stdout
 resetMock({status: 0, stdout: ''})
 result = dockerLambda()
-result === void 0 // Result is undefined and does not contain `should`
+should.not.exist(result)
 
 // Should throw error if spawn returns error
 resetMock({error: new Error('Something went wrong')})


### PR DESCRIPTION
Lambda function stdout is now split on `\n` character to get the last value. This assumes the last value in stdout is the result object from the Lambda function. If it cannot be parsed, it is returned as a string. If stdout has no entries, an empty string will be returned to the caller.

Fixes #16 