### PR TITLE
This example has changed since this was created

### DIFF
--- a/examples/module-native/package.json
+++ b/examples/module-native/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "docker run -v \"$PWD\":/var/task lambci/lambda-build",
+    "build": "docker run -v \"$PWD\":/var/task lambci/lambda:build",
     "test": "node test.js"
   },
   "dependencies": {


### PR DESCRIPTION
There is no distinct `lambci\lambda-build` container but instead a branch of the `lambci\lambda` container per [docs](https://github.com/lambci/docker-lambda/blame/master/README.md#L55).