### PR TITLE
Install essential system libraries for built-in modules in python3

### DIFF
--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -5,12 +5,18 @@ ENV PATH=/var/lang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/
     AWS_EXECUTION_ENV=AWS_Lambda_python3.6 \
     PYTHONPATH=/var/runtime
 
+# For 'clean all' justification, see https://github.com/CentOS/sig-cloud-instance-images/issues/15
+# and for 'touch' hack see https://docs.docker.com/engine/userguide/storagedriver/overlayfs-driver/#limitations-on-overlayfs-compatibility
+RUN touch /var/lib/rpm/* && \
+  yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl openssl-devel && \
+  yum clean all
+
 RUN rm -rf /var/runtime /var/lang && \
   curl https://lambci.s3.amazonaws.com/fs/python3.6.tgz | tar -xz -C / && \
   curl https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz | tar -xJ && \
   cd Python-3.6.1 && \
-  ./configure --prefix=/var/lang && \
-  make -j$(getconf _NPROCESSORS_ONLN) libinstall inclinstall && \
+  ./configure --prefix=/var/lang --enable-shared && \
+  make -j$(getconf _NPROCESSORS_ONLN) install && \
   cd .. && \
   rm -rf Python-3.6.1 && \
   pip3 install awscli

--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -19,4 +19,4 @@ RUN rm -rf /var/runtime /var/lang && \
   make -j$(getconf _NPROCESSORS_ONLN) install && \
   cd .. && \
   rm -rf Python-3.6.1 && \
-  pip3 install awscli
+  pip3 install awscli --no-cache-dir


### PR DESCRIPTION
This fixes the missing libraries for built-in modules like bz2 or sqlite.