### PR TITLE
_GLOBAL_TIMEOUT is invalid type on Python 

### DIFF
--- a/python2.7/run/runtime-mock.py
+++ b/python2.7/run/runtime-mock.py
@@ -72,6 +72,18 @@ os.environ['AWS_LAMBDA_FUNCTION_VERSION'] = _GLOBAL_VERSION
 os.environ['AWS_REGION'] = _GLOBAL_REGION
 os.environ['AWS_DEFAULT_REGION'] = _GLOBAL_REGION
 
+def report_user_init_start():
+    return
+
+def report_user_init_end():
+    return
+
+def report_user_invoke_start():
+    return
+
+def report_user_invoke_end():
+    return
+
 def receive_start():
     sys.stdout = orig_stderr
     sys.stderr = orig_stderr
@@ -127,7 +139,7 @@ def report_done(invokeid, errortype, result):
         eprint("END RequestId: %s" % invokeid)
 
         duration = int((time.time() - _GLOBAL_START_TIME) * 1000)
-        billed_duration = min(100 * ((duration / 100) + 1), _GLOBAL_TIMEOUT * 1000)
+        billed_duration = min(100 * ((duration / 100) + 1), int(_GLOBAL_TIMEOUT) * 1000)
         max_mem = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
 
         eprint(
@@ -152,7 +164,7 @@ def log_sb(msg):
     return
 
 def get_remaining_time():
-    return ((_GLOBAL_TIMEOUT * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
+    return ((int(_GLOBAL_TIMEOUT) * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
 
 def send_console_message(msg):
     eprint(msg)

--- a/python2.7/run/runtime-mock.py
+++ b/python2.7/run/runtime-mock.py
@@ -27,7 +27,7 @@ _GLOBAL_EVENT_BODY = sys.argv[2] if len(sys.argv) > 2 else os.environ.get('AWS_L
 _GLOBAL_FCT_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME', 'test')
 _GLOBAL_VERSION = os.environ.get('AWS_LAMBDA_FUNCTION_VERSION', '$LATEST')
 _GLOBAL_MEM_SIZE = os.environ.get('AWS_LAMBDA_FUNCTION_MEMORY_SIZE', 1536)
-_GLOBAL_TIMEOUT = os.environ.get('AWS_LAMBDA_FUNCTION_TIMEOUT', 300)
+_GLOBAL_TIMEOUT = int(os.environ.get('AWS_LAMBDA_FUNCTION_TIMEOUT', 300))
 _GLOBAL_REGION = os.environ.get('AWS_REGION', 'us-east-1')
 _GLOBAL_ACCOUNT_ID = os.environ.get('AWS_ACCOUNT_ID', _random_account_id())
 _GLOBAL_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', 'SOME_ACCESS_KEY_ID')
@@ -139,7 +139,7 @@ def report_done(invokeid, errortype, result):
         eprint("END RequestId: %s" % invokeid)
 
         duration = int((time.time() - _GLOBAL_START_TIME) * 1000)
-        billed_duration = min(100 * ((duration / 100) + 1), int(_GLOBAL_TIMEOUT) * 1000)
+        billed_duration = min(100 * ((duration / 100) + 1), _GLOBAL_TIMEOUT * 1000)
         max_mem = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
 
         eprint(
@@ -164,7 +164,7 @@ def log_sb(msg):
     return
 
 def get_remaining_time():
-    return ((int(_GLOBAL_TIMEOUT) * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
+    return ((_GLOBAL_TIMEOUT * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
 
 def send_console_message(msg):
     eprint(msg)

--- a/python3.6/run/runtime-mock.py
+++ b/python3.6/run/runtime-mock.py
@@ -72,6 +72,18 @@ os.environ['AWS_LAMBDA_FUNCTION_VERSION'] = _GLOBAL_VERSION
 os.environ['AWS_REGION'] = _GLOBAL_REGION
 os.environ['AWS_DEFAULT_REGION'] = _GLOBAL_REGION
 
+def report_user_init_start():
+    return
+
+def report_user_init_end():
+    return
+
+def report_user_invoke_start():
+    return
+
+def report_user_invoke_end():
+    return
+
 def receive_start():
     sys.stdout = orig_stderr
     sys.stderr = orig_stderr
@@ -127,7 +139,7 @@ def report_done(invokeid, errortype, result):
         eprint("END RequestId: %s" % invokeid)
 
         duration = int((time.time() - _GLOBAL_START_TIME) * 1000)
-        billed_duration = min(100 * ((duration / 100) + 1), _GLOBAL_TIMEOUT * 1000)
+        billed_duration = min(100 * ((duration / 100) + 1), int(_GLOBAL_TIMEOUT) * 1000)
         max_mem = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
 
         eprint(
@@ -152,7 +164,7 @@ def log_sb(msg):
     return
 
 def get_remaining_time():
-    return ((_GLOBAL_TIMEOUT * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
+    return ((int(_GLOBAL_TIMEOUT) * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
 
 def send_console_message(msg):
     eprint(msg)

--- a/python3.6/run/runtime-mock.py
+++ b/python3.6/run/runtime-mock.py
@@ -27,7 +27,7 @@ _GLOBAL_EVENT_BODY = sys.argv[2] if len(sys.argv) > 2 else os.environ.get('AWS_L
 _GLOBAL_FCT_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME', 'test')
 _GLOBAL_VERSION = os.environ.get('AWS_LAMBDA_FUNCTION_VERSION', '$LATEST')
 _GLOBAL_MEM_SIZE = os.environ.get('AWS_LAMBDA_FUNCTION_MEMORY_SIZE', 1536)
-_GLOBAL_TIMEOUT = os.environ.get('AWS_LAMBDA_FUNCTION_TIMEOUT', 300)
+_GLOBAL_TIMEOUT = int(os.environ.get('AWS_LAMBDA_FUNCTION_TIMEOUT', 300))
 _GLOBAL_REGION = os.environ.get('AWS_REGION', 'us-east-1')
 _GLOBAL_ACCOUNT_ID = os.environ.get('AWS_ACCOUNT_ID', _random_account_id())
 _GLOBAL_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', 'SOME_ACCESS_KEY_ID')
@@ -139,7 +139,7 @@ def report_done(invokeid, errortype, result):
         eprint("END RequestId: %s" % invokeid)
 
         duration = int((time.time() - _GLOBAL_START_TIME) * 1000)
-        billed_duration = min(100 * ((duration / 100) + 1), int(_GLOBAL_TIMEOUT) * 1000)
+        billed_duration = min(100 * ((duration / 100) + 1), _GLOBAL_TIMEOUT * 1000)
         max_mem = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
 
         eprint(
@@ -164,7 +164,7 @@ def log_sb(msg):
     return
 
 def get_remaining_time():
-    return ((int(_GLOBAL_TIMEOUT) * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
+    return ((_GLOBAL_TIMEOUT * 1000) - int((time.time() - _GLOBAL_START_TIME) * 1000))
 
 def send_console_message(msg):
     eprint(msg)


### PR DESCRIPTION
I run lambda:python3.6 with `AWS_LAMBDA_FUNCTION_TIMEOUT`
The container show me an error message. 
```

$ docker run -v "$PWD":/var/task -e AWS_LAMBDA_FUNCTION_TIMEOUT=1 lambci/lambda:python3.6
START RequestId: 9d3dab1a-855f-4f82-a5b4-73bc6a320c03 Version: $LATEST
END RequestId: 9d3dab1a-855f-4f82-a5b4-73bc6a320c03
Traceback (most recent call last):
  File "/var/runtime/awslambda/bootstrap.py", line 466, in <module>
    main()
  File "/var/runtime/awslambda/bootstrap.py", line 462, in main
    handle_event_request(request_handler, invokeid, event_body, context_objs, invoked_function_arn)
  File "/var/runtime/awslambda/bootstrap.py", line 250, in handle_event_request
    lambda_runtime.report_done(invokeid, errortype, result)
  File "/var/runtime/awslambda/runtime.py", line 130, in report_done
    billed_duration = min(100 * ((duration / 100) + 1), _GLOBAL_TIMEOUT * 1000)
TypeError: '<' not supported between instances of 'str' and 'float'
```

I checked the line on runtime-mock.py which is written in the error message.
`billed_duration = min(100 * ((duration / 100) + 1), _GLOBAL_TIMEOUT * 1000)`

`_GLOBAL_TIMEOUT` is defined in the fist part of the file.
`_GLOBAL_TIMEOUT = os.environ.get('AWS_LAMBDA_FUNCTION_TIMEOUT', 300)` 
if AWS_LAMBDA_FUNCTION_TIMEOUT is not defined in environment variables then _GLOBAL_TIMEOUT type is str.  not number(int, float).

also python2 can call min() with str and float , but python3 check strictly type which can't compere str to number.

btw, I added new 4 function to build docker image. the functions exist on original runtime.so.
