### PR TITLE
Use --no-cache-dir when using pip install.

### DIFF
--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -13,4 +13,4 @@ RUN rm -rf /var/runtime /var/lang && \
   make -j$(getconf _NPROCESSORS_ONLN) libinstall inclinstall && \
   cd .. && \
   rm -rf Python-3.6.1 && \
-  pip3 install awscli
+  pip3 install awscli --no-cache-dir


### PR DESCRIPTION
This avoids leaving /root/.cache directory with cached.

This particularly causes `serverless-python-requirements` to fail building packages.