### PR TITLE
Install virtualenv in python3 docker image

### DIFF
--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -13,4 +13,4 @@ RUN rm -rf /var/runtime /var/lang && \
   make -j$(getconf _NPROCESSORS_ONLN) libinstall inclinstall && \
   cd .. && \
   rm -rf Python-3.6.1 && \
-  pip3 install awscli --no-cache-dir
+  pip3 install awscli virtualenv --no-cache-dir


### PR DESCRIPTION
The python3 docker image currently doesn't install `virtualenv` as the python2 image does. This PR changes the python3 docker image to install `virtualenv` as well and aligns the behavior.

Please have a look