### PR TITLE
Came up with a way to send large custom events into a Lambda (fixes #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ docker run --rm -v "$PWD":/var/task lambci/lambda:java8 org.myorg.MyHandler
 
 # Run custom commands on the default container
 docker run --rm --entrypoint node lambci/lambda -v
+
+# Use the Node.js v6.10 runtime with a large custom event stored in a file ~/my_event/event.json
+docker run --rm -v "$PWD":/var/task -v ~/my_event:/var/event lambci/lambda:nodejs6.10
 ```
 
 You can see more examples of how to build docker images and run different

--- a/nodejs/run/awslambda-mock.js
+++ b/nodejs/run/awslambda-mock.js
@@ -1,7 +1,14 @@
 var crypto = require('crypto')
+var fs = require('fs')
 
 var HANDLER = process.argv[2] || process.env.AWS_LAMBDA_FUNCTION_HANDLER || process.env._HANDLER ||  'index.handler'
-var EVENT_BODY = process.argv[3] || process.env.AWS_LAMBDA_EVENT_BODY || '{}'
+
+var READ_BODY = null;
+try {
+  READ_BODY = fs.readFileSync('/var/event/event.json', 'utf8');
+} catch (e) {
+}
+var EVENT_BODY = READ_BODY || process.argv[3] || process.env.AWS_LAMBDA_EVENT_BODY || '{}'
 
 var FN_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME || 'test'
 var VERSION = process.env.AWS_LAMBDA_FUNCTION_VERSION || '$LATEST'

--- a/nodejs4.3/run/awslambda-mock.js
+++ b/nodejs4.3/run/awslambda-mock.js
@@ -1,7 +1,13 @@
 var crypto = require('crypto')
 
 var HANDLER = process.argv[2] || process.env.AWS_LAMBDA_FUNCTION_HANDLER || process.env._HANDLER ||  'index.handler'
-var EVENT_BODY = process.argv[3] || process.env.AWS_LAMBDA_EVENT_BODY || '{}'
+
+var READ_BODY = null;
+try {
+  READ_BODY = fs.readFileSync('/var/event/event.json', 'utf8');
+} catch (e) {
+}
+var EVENT_BODY = READ_BODY || process.argv[3] || process.env.AWS_LAMBDA_EVENT_BODY || '{}'
 
 var FN_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME || 'test'
 var VERSION = process.env.AWS_LAMBDA_FUNCTION_VERSION || '$LATEST'

--- a/nodejs6.10/run/awslambda-mock.js
+++ b/nodejs6.10/run/awslambda-mock.js
@@ -1,7 +1,14 @@
 var crypto = require('crypto')
+var fs = require('fs')
 
 var HANDLER = process.argv[2] || process.env.AWS_LAMBDA_FUNCTION_HANDLER || process.env._HANDLER ||  'index.handler'
-var EVENT_BODY = process.argv[3] || process.env.AWS_LAMBDA_EVENT_BODY || '{}'
+
+var READ_BODY = null;
+try {
+  READ_BODY = fs.readFileSync('/var/event/event.json', 'utf8');
+} catch (e) {
+}
+var EVENT_BODY = READ_BODY || process.argv[3] || process.env.AWS_LAMBDA_EVENT_BODY || '{}'
 
 var FN_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME || 'test'
 var VERSION = process.env.AWS_LAMBDA_FUNCTION_VERSION || '$LATEST'

--- a/python2.7/run/runtime-mock.py
+++ b/python2.7/run/runtime-mock.py
@@ -23,7 +23,11 @@ def _arn(region, account_id, fct_name):
     return 'arn:aws:lambda:%s:%s:function:%s' % (region, account_id, fct_name)
 
 _GLOBAL_HANDLER = sys.argv[1] if len(sys.argv) > 1 else os.environ.get('AWS_LAMBDA_FUNCTION_HANDLER', os.environ.get('_HANDLER', 'lambda_function.lambda_handler'))
-_GLOBAL_EVENT_BODY = sys.argv[2] if len(sys.argv) > 2 else os.environ.get('AWS_LAMBDA_EVENT_BODY', '{}')
+if os.path.exists('/var/event/event.json'):
+    with open('/var/event/event.json', 'r') as event_file:
+        _GLOBAL_EVENT_BODY = event_file.read()
+else:
+    _GLOBAL_EVENT_BODY = sys.argv[2] if len(sys.argv) > 2 else os.environ.get('AWS_LAMBDA_EVENT_BODY', '{}')
 _GLOBAL_FCT_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME', 'test')
 _GLOBAL_VERSION = os.environ.get('AWS_LAMBDA_FUNCTION_VERSION', '$LATEST')
 _GLOBAL_MEM_SIZE = os.environ.get('AWS_LAMBDA_FUNCTION_MEMORY_SIZE', '1536')

--- a/python3.6/run/runtime-mock.py
+++ b/python3.6/run/runtime-mock.py
@@ -23,7 +23,11 @@ def _arn(region, account_id, fct_name):
     return 'arn:aws:lambda:%s:%s:function:%s' % (region, account_id, fct_name)
 
 _GLOBAL_HANDLER = sys.argv[1] if len(sys.argv) > 1 else os.environ.get('AWS_LAMBDA_FUNCTION_HANDLER', os.environ.get('_HANDLER', 'lambda_function.lambda_handler'))
-_GLOBAL_EVENT_BODY = sys.argv[2] if len(sys.argv) > 2 else os.environ.get('AWS_LAMBDA_EVENT_BODY', '{}')
+if os.path.exists('/var/event/event.json'):
+    with open('/var/event/event.json', 'r') as event_file:
+        _GLOBAL_EVENT_BODY = event_file.read()
+else:
+    _GLOBAL_EVENT_BODY = sys.argv[2] if len(sys.argv) > 2 else os.environ.get('AWS_LAMBDA_EVENT_BODY', '{}')
 _GLOBAL_FCT_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME', 'test')
 _GLOBAL_VERSION = os.environ.get('AWS_LAMBDA_FUNCTION_VERSION', '$LATEST')
 _GLOBAL_MEM_SIZE = os.environ.get('AWS_LAMBDA_FUNCTION_MEMORY_SIZE', '1536')


### PR DESCRIPTION
In #64, a lot of folks seem to be having problems sending large custom events to Docker because of the limit with the number of characters one can pass, either through program arguments or enviroment variables. As far as I know, there is no way to pass a string over a certain limit through this method.

I came up with an alternate method that works. If my PR were merged, the following would be possible:

```
docker run --rm -v "$PWD":/var/task -v "$PWD":/var/event lambci/lambda:nodejs6.10
```

It's pretty simple: you just create a new Docker volume with a standard path and look for an event with a certain filename within that volume. It's also pretty ugly, so I'd understand if you didn't like this solution.

I've done this fix for the Node and Python runtimes, but it wasn't convenient for me to do the Go and Java ones as this time. So that's a TODO.