### PR TITLE
Include vgo in the go build image

### DIFF
--- a/go1.x/build/Dockerfile
+++ b/go1.x/build/Dockerfile
@@ -11,6 +11,7 @@ RUN rm -rf /var/runtime /var/lang && \
   curl https://lambci.s3.amazonaws.com/fs/go1.x.tgz | tar -zx -C / && \
   curl https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar -zx -C /usr/local && \
   go get github.com/golang/dep/cmd/dep && \
-  go install github.com/golang/dep/cmd/dep
+  go install github.com/golang/dep/cmd/dep && \
+  go get golang.org/x/vgo
 
 CMD ["dep", "ensure"]


### PR DESCRIPTION
vgo is starting to replace dep in go applications. I've added this to the build image so people starting new go projects can take advantage 👍 