### PR TITLE
adding maven to build-java8

### DIFF
--- a/java8/build/Dockerfile
+++ b/java8/build/Dockerfile
@@ -6,4 +6,8 @@ WORKDIR /
 
 RUN rm -rf /var/runtime /var/lang && \
   curl https://lambci.s3.amazonaws.com/fs/java8.tgz | tar -zx -C / && \
-  yum install -y java-1.8.0-openjdk-devel
+  yum install -y java-1.8.0-openjdk-devel && \
+  curl -L http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -o /etc/yum.repos.d/epel-apache-maven.repo && \
+  sed -i s/\$releasever/7/g /etc/yum.repos.d/epel-apache-maven.repo && \
+  yum clean all && \
+  yum install -y apache-maven


### PR DESCRIPTION
As a build container for java, maven should be installed since it will be needed by most java projects. Similar to `dep` in go