### PR TITLE
[FIX] python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6m.a: No such file or directory

### DIFF
--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -12,7 +12,7 @@ RUN rm -rf /var/runtime /var/lang && \
   curl https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz | tar -xJ && \
   cd Python-3.6.1 && \
   LIBS="$LIBS -lutil -lrt" ./configure --prefix=/var/lang && \
-  make -j$(getconf _NPROCESSORS_ONLN) libinstall inclinstall && \
+  make -j$(getconf _NPROCESSORS_ONLN) libinstall libainstall inclinstall && \
   cd .. && \
   rm -rf Python-3.6.1 && \
   pip3 install -U pip awscli virtualenv pipenv --no-cache-dir


### PR DESCRIPTION
Executes `libainstall` on Python installation. It provides `/var/lang/lib/python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6m.a`, needed to compile some packages. For exemple, uWSGI:

```
# pip install uwsgi
Collecting uwsgi
  Downloading https://files.pythonhosted.org/packages/a2/c9/a2d5737f63cd9df4317a4acc15d1ddf4952e28398601d8d7d706c16381e0/uwsgi-2.0.17.1.tar.gz (800kB)
    100% |████████████████████████████████| 808kB 9.9MB/s
Installing collected packages: uwsgi
  Running setup.py install for uwsgi ... error
    Complete output from command /var/lang//bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-p2ky0__w/uwsgi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-ho90ozms/install-record.txt --single-version-externally-managed --compile:
    /var/lang/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'descriptions'
      warnings.warn(msg)
    running install
    using profile: buildconf/default.ini
    detected include path: ['/usr/lib/gcc/x86_64-amazon-linux/4.8.3/include', '/usr/local/include', '/usr/include']
    Patching "bin_name" to properly install_scripts dir
    detected CPU cores: 2
    configured CFLAGS: -O2 -I. -Wall -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format -Wno-format-security -DUWSGI_HAS_IFADDRS -DUWSGI_ZLIB -DUWSGI_LOCK_USE_MUTEX -DUWSGI_EVENT_USE_EPOLL -DUWSGI_EVENT_TIMER_USE_TIMERFD -DUWSGI_EVENT_FILEMONITOR_USE_INOTIFY -DUWSGI_VERSION="\"2.0.17.1\"" -DUWSGI_VERSION_BASE="2" -DUWSGI_VERSION_MAJOR="0" -DUWSGI_VERSION_MINOR="17" -DUWSGI_VERSION_REVISION="1" -DUWSGI_VERSION_CUSTOM="\"\"" -DUWSGI_YAML -DUWSGI_SSL -DUWSGI_PLUGIN_DIR="\".\"" -DUWSGI_DECLARE_EMBEDDED_PLUGINS="UDEP(python);UDEP(gevent);UDEP(ping);UDEP(cache);UDEP(nagios);UDEP(rrdtool);UDEP(carbon);UDEP(rpc);UDEP(corerouter);UDEP(fastrouter);UDEP(http);UDEP(ugreen);UDEP(signal);UDEP(syslog);UDEP(rsyslog);UDEP(logsocket);UDEP(router_uwsgi);UDEP(router_redirect);UDEP(router_basicauth);UDEP(zergpool);UDEP(redislog);UDEP(mongodblog);UDEP(router_rewrite);UDEP(router_http);UDEP(logfile);UDEP(router_cache);UDEP(rawrouter);UDEP(router_static);UDEP(sslrouter);UDEP(spooler);UDEP(cheaper_busyness);UDEP(symcall);UDEP(transformation_tofile);UDEP(transformation_gzip);UDEP(transformation_chunked);UDEP(transformation_offload);UDEP(router_memcached);UDEP(router_redis);UDEP(router_hash);UDEP(router_expires);UDEP(router_metrics);UDEP(transformation_template);UDEP(stats_pusher_socket);" -DUWSGI_LOAD_EMBEDDED_PLUGINS="ULEP(python);ULEP(gevent);ULEP(ping);ULEP(cache);ULEP(nagios);ULEP(rrdtool);ULEP(carbon);ULEP(rpc);ULEP(corerouter);ULEP(fastrouter);ULEP(http);ULEP(ugreen);ULEP(signal);ULEP(syslog);ULEP(rsyslog);ULEP(logsocket);ULEP(router_uwsgi);ULEP(router_redirect);ULEP(router_basicauth);ULEP(zergpool);ULEP(redislog);ULEP(mongodblog);ULEP(router_rewrite);ULEP(router_http);ULEP(logfile);ULEP(router_cache);ULEP(rawrouter);ULEP(router_static);ULEP(sslrouter);ULEP(spooler);ULEP(cheaper_busyness);ULEP(symcall);ULEP(transformation_tofile);ULEP(transformation_gzip);ULEP(transformation_chunked);ULEP(transformation_offload);ULEP(router_memcached);ULEP(router_redis);ULEP(router_hash);ULEP(router_expires);ULEP(router_metrics);ULEP(transformation_template);ULEP(stats_pusher_socket);"
    *** uWSGI compiling server core ***
    [thread 1][gcc -pthread] core/utils.o
    [thread 0][gcc -pthread] core/protocol.o
    [thread 0][gcc -pthread] core/socket.o
 (...)
    [thread 1][gcc -pthread] core/dot_h.o
    [thread 1][gcc -pthread] core/config_py.o
    *** uWSGI compiling embedded plugins ***
    [thread 1][gcc -pthread] plugins/python/python_plugin.o
    [thread 0][gcc -pthread] plugins/python/pyutils.o
 (...)
    [thread 0][gcc -pthread] plugins/router_metrics/plugin.o
    [thread 1][gcc -pthread] plugins/transformation_template/tt.o
    [thread 0][gcc -pthread] plugins/stats_pusher_socket/plugin.o
    *** uWSGI linking ***
    gcc -pthread -o /var/lang/bin/uwsgi  core/utils.o core/protocol.o core/socket.o core/logging.o core/master.o core/master_utils.o core/emperor.o core/notify.o core/mule.o core/subscription.o core/stats.o core/sendfile.o core/async.o core/master_checks.o core/fifo.o core/offload.o core/io.o core/static.o core/websockets.o core/spooler.o core/snmp.o core/exceptions.o core/config.o core/setup_utils.o core/clock.o core/init.o core/buffer.o core/reader.o core/writer.o core/alarm.o core/cron.o core/hooks.o core/plugins.o core/lock.o core/cache.o core/daemons.o core/errors.o core/hash.o core/master_events.o core/chunked.o core/queue.o core/event.o core/signal.o core/strings.o core/progress.o core/timebomb.o core/ini.o core/fsmon.o core/mount.o core/metrics.o core/plugins_builder.o core/sharedarea.o core/rpc.o core/gateway.o core/loop.o core/cookie.o core/querystring.o core/rb_timers.o core/transformations.o core/uwsgi.o proto/base.o proto/uwsgi.o proto/http.o proto/fastcgi.o proto/scgi.o proto/puwsgi.o lib/linux_ns.o core/zlib.o core/yaml.o core/ssl.o core/legion.o core/dot_h.o core/config_py.o plugins/python/python_plugin.o plugins/python/pyutils.o plugins/python/pyloader.o plugins/python/wsgi_handlers.o plugins/python/wsgi_headers.o plugins/python/wsgi_subhandler.o plugins/python/web3_subhandler.o plugins/python/pump_subhandler.o plugins/python/gil.o plugins/python/uwsgi_pymodule.o plugins/python/profiler.o plugins/python/symimporter.o plugins/python/tracebacker.o plugins/python/raw.o plugins/gevent/gevent.o plugins/gevent/hooks.o plugins/ping/ping_plugin.o plugins/cache/cache.o plugins/nagios/nagios.o plugins/rrdtool/rrdtool.o plugins/carbon/carbon.o plugins/rpc/rpc_plugin.o plugins/corerouter/cr_common.o plugins/corerouter/cr_map.o plugins/corerouter/corerouter.o plugins/fastrouter/fastrouter.o plugins/http/http.o plugins/http/keepalive.o plugins/http/https.o plugins/http/spdy3.o plugins/ugreen/ugreen.o plugins/signal/signal_plugin.o plugins/syslog/syslog_plugin.o plugins/rsyslog/rsyslog_plugin.o plugins/logsocket/logsocket_plugin.o plugins/router_uwsgi/router_uwsgi.o plugins/router_redirect/router_redirect.o plugins/router_basicauth/router_basicauth.o plugins/zergpool/zergpool.o plugins/redislog/redislog_plugin.o plugins/mongodblog/mongodblog_plugin.o plugins/router_rewrite/router_rewrite.o plugins/router_http/router_http.o plugins/logfile/logfile.o plugins/router_cache/router_cache.o plugins/rawrouter/rawrouter.o plugins/router_static/router_static.o plugins/sslrouter/sslrouter.o plugins/spooler/spooler_plugin.o plugins/cheaper_busyness/cheaper_busyness.o plugins/symcall/symcall_plugin.o plugins/transformation_tofile/tofile.o plugins/transformation_gzip/gzip.o plugins/transformation_chunked/chunked.o plugins/transformation_offload/offload.o plugins/router_memcached/router_memcached.o plugins/router_redis/router_redis.o plugins/router_hash/router_hash.o plugins/router_expires/expires.o plugins/router_metrics/plugin.o plugins/transformation_template/tt.o plugins/stats_pusher_socket/plugin.o -lpthread -lm -rdynamic -ldl -lz -lssl -lcrypto -lpthread -ldl -lutil -lrt -lm /var/lang/lib/python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6m.a -lutil -lcrypt
    gcc: error: /var/lang/lib/python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6m.a: No such file or directory
    *** error linking uWSGI ***

    ----------------------------------------
Command "/var/lang//bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-p2ky0__w/uwsgi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-ho90ozms/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-install-p2ky0__w/uwsgi/
```