### PR TITLE
RPM DB broken on layered filesystems

### DIFF
--- a/base/build/Dockerfile
+++ b/base/build/Dockerfile
@@ -4,7 +4,18 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # A couple of packages are either missing critical-ish files, or didn't make it into the tar
 # Reinstalling filesystem might not succeed fully, but continue anyway
-RUN chmod 1777 /tmp && yum reinstall -y filesystem; \
+RUN chmod 1777 /tmp && \
+  /usr/bin/python3 -c "from configparser import SafeConfigParser; \
+yum_conf = SafeConfigParser(); \
+yum_conf.read('/etc/yum.conf'); \
+yum_conf.has_section('main') or yum_conf.add_section('main'); \
+yum_conf.set('main', 'plugins', '1'); \
+f = open('/etc/yum.conf', 'w'); \
+yum_conf.write(f); \
+f.close();" && \
+  rpm --rebuilddb && \
+  yum install -y yum-plugin-ovl && \
+  yum reinstall -y filesystem; \
   yum reinstall -y shadow-utils && \
   yum groupinstall -y development && \
   yum install -y clang cmake aws-cli docker \


### PR DESCRIPTION
After the recent release of `lambci/lambda:build-python3.6`, I've noticed the installation of system packages with YUM using `lambci/lambda:build-python3.6` doesn't work and I think eventually all other Docker images are affected as well. I need to install another system packages, mostly `devel` pkgs to install compiled Python' PYPI packages, like `pymysql`.

**The issue is in the YUM's rpmdb and the error is reproducible when trying to install any package, for example this was my case:**

`docker run -it lambci/lambda:build-python3.6 bash -c 'yum install -y freetds-devel'`

The entire operation fails with exit code `1` and displays the following error:
`Rpmdb checksum is invalid: dCDPT(pkg checksums): freetds.x86_64 0:0.91-2.3.amzn1 - u`

This unfortunately seems to be a known issue confirmed by RedHat, it's caused by `yum` running on a layered filesystem, like `overlay` or `aufs`:
https://docs.docker.com/v17.09/engine/userguide/storagedriver/overlayfs-driver/#performance-best-practices

The `yum` issue is described here: https://bugzilla.redhat.com/show_bug.cgi?id=1213602
`yum` first opens the `rpmdb` file in a read-only mode, so the filesystem doesn't expect a modification and return back an i-node of an existing lower layer. After that, file is open in read/write mode which results in a new higher layer being created and another i-node being returned.

There's is a workaround for that, `yum` has a plugin packaged as `yum-plugin-ovl` RPM that accesses yum files at every yum transaction, makes the higher layer modification visible and thus makes the layered filesystem usable for yum's rpmdb. 
https://github.com/rpm-software-management/yum-utils/blob/master/plugins/ovl/ovl.py#L46

Unfortunately, the `/etc/yum.conf` file is empty and default value for plugins is to be disabled:
`docker run -it lambci/lambda:build-python3.6 bash -c 'cat /etc/yum.conf; echo done'`
`done`

https://linux.die.net/man/5/yum.conf
```plugins Either '0' or '1'. Global switch to enable or disable yum plugins. Default is '0' (plugins disabled). See the PLUGINS section of the yum(8) man for more information on installing yum plugins. ```

For these reasons, I think the only reasonable way of making the `yum` working again is to enable the yum plugins, install the plugin and rebuild the rpmdb. `/etc/yum.conf` is an INI file, so I used Python's `configparser` to safely set just the `[main] plugins=1` - in case the `/etc/yum.conf` changes in the future.

I've built an image based on the modified Dockerfile:
`docker build --no-cache -t docker-lambda:local-test .`

And then I successfully installed a package with YUM:
`docker run --rm -it docker-lambda:local-test bash -c 'yum install -y freetds-devel'`
```
Loaded plugins: ovl
amzn-main                                                                                                                                                                                                   | 2.1 kB  00:00:00     
amzn-updates                                                                                                                                                                                                | 2.3 kB  00:00:00     
(1/5): amzn-main/2017.03/group                                                                                                                                                                              |  35 kB  00:00:00     
(2/5): amzn-updates/2017.03/group                                                                                                                                                                           |  35 kB  00:00:00     
(3/5): amzn-updates/2017.03/updateinfo                                                                                                                                                                      | 421 kB  00:00:02     
(4/5): amzn-updates/2017.03/primary_db                                                                                                                                                                      | 1.2 MB  00:00:02     
(5/5): amzn-main/2017.03/primary_db                                                                                                                                                                         | 3.6 MB  00:00:09     
Resolving Dependencies
--> Running transaction check
---> Package freetds-devel.x86_64 0:0.91-2.3.amzn1 will be installed
--> Processing Dependency: freetds = 0.91-2.3.amzn1 for package: freetds-devel-0.91-2.3.amzn1.x86_64
--> Processing Dependency: libct.so.4()(64bit) for package: freetds-devel-0.91-2.3.amzn1.x86_64
--> Processing Dependency: libtdsodbc.so.0()(64bit) for package: freetds-devel-0.91-2.3.amzn1.x86_64
--> Processing Dependency: libsybdb.so.5()(64bit) for package: freetds-devel-0.91-2.3.amzn1.x86_64
--> Running transaction check
---> Package freetds.x86_64 0:0.91-2.3.amzn1 will be installed
--> Processing Dependency: libodbcinst.so.2()(64bit) for package: freetds-0.91-2.3.amzn1.x86_64
--> Processing Dependency: libodbc.so.2()(64bit) for package: freetds-0.91-2.3.amzn1.x86_64
--> Running transaction check
---> Package unixODBC.x86_64 0:2.2.14-14.7.amzn1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

===================================================================================================================================================================================================================================
 Package                                                 Arch                                             Version                                                        Repository                                           Size
===================================================================================================================================================================================================================================
Installing:
 freetds-devel                                           x86_64                                           0.91-2.3.amzn1                                                 amzn-main                                            40 k
Installing for dependencies:
 freetds                                                 x86_64                                           0.91-2.3.amzn1                                                 amzn-main                                           1.0 M
 unixODBC                                                x86_64                                           2.2.14-14.7.amzn1                                              amzn-main                                           483 k

Transaction Summary
===================================================================================================================================================================================================================================
Install  1 Package (+2 Dependent packages)

Total download size: 1.5 M
Installed size: 3.9 M
Downloading packages:
(1/3): freetds-devel-0.91-2.3.amzn1.x86_64.rpm                                                                                                                                                              |  40 kB  00:00:01     
(2/3): freetds-0.91-2.3.amzn1.x86_64.rpm                                                                                                                                                                    | 1.0 MB  00:00:03     
(3/3): unixODBC-2.2.14-14.7.amzn1.x86_64.rpm                                                                                                                                                                | 483 kB  00:00:06     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                              242 kB/s | 1.5 MB  00:00:06     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : unixODBC-2.2.14-14.7.amzn1.x86_64                                                                                                                                                                               1/3 
  Installing : freetds-0.91-2.3.amzn1.x86_64                                                                                                                                                                                   2/3 
  Installing : freetds-devel-0.91-2.3.amzn1.x86_64                                                                                                                                                                             3/3 
  Verifying  : freetds-devel-0.91-2.3.amzn1.x86_64                                                                                                                                                                             1/3 
  Verifying  : freetds-0.91-2.3.amzn1.x86_64                                                                                                                                                                                   2/3 
  Verifying  : unixODBC-2.2.14-14.7.amzn1.x86_64                                                                                                                                                                               3/3 

Installed:
  freetds-devel.x86_64 0:0.91-2.3.amzn1                                                                                                                                                                                            

Dependency Installed:
  freetds.x86_64 0:0.91-2.3.amzn1                                                                                unixODBC.x86_64 0:2.2.14-14.7.amzn1                                                                               

Complete!
```

I think I'm not the only one who really likes this Docker image and uses it for testing of Lambda functions, so I think contributing to the base project might be useful for multiple people.

Thanks.
Kamil