### PR TITLE
Fix: X-Ray trace ID for nodejs runtimes

### DIFF
--- a/nodejs4.3/run/awslambda-mock.js
+++ b/nodejs4.3/run/awslambda-mock.js
@@ -15,6 +15,7 @@ var ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'SOME_ACCESS_KEY_ID'
 var SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'SOME_SECRET_ACCESS_KEY'
 var SESSION_TOKEN = process.env.AWS_SESSION_TOKEN
 var INVOKED_ARN = process.env.AWS_LAMBDA_FUNCTION_INVOKED_ARN || arn(REGION, ACCOUNT_ID, FN_NAME)
+var XRAY_TRACE_ID = process.env._X_AMZN_TRACE_ID
 
 function consoleLog(str) {
   process.stderr.write(formatConsole(str))
@@ -70,6 +71,8 @@ var OPTIONS = {
 
 // Some weird spelling error in the source?
 OPTIONS.invokeid = OPTIONS.invokeId
+
+OPTIONS['x-amzn-trace-id'] = XRAY_TRACE_ID
 
 var invoked = false
 var errored = false

--- a/nodejs6.10/run/awslambda-mock.js
+++ b/nodejs6.10/run/awslambda-mock.js
@@ -15,6 +15,7 @@ var ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'SOME_ACCESS_KEY_ID'
 var SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'SOME_SECRET_ACCESS_KEY'
 var SESSION_TOKEN = process.env.AWS_SESSION_TOKEN
 var INVOKED_ARN = process.env.AWS_LAMBDA_FUNCTION_INVOKED_ARN || arn(REGION, ACCOUNT_ID, FN_NAME)
+var XRAY_TRACE_ID = process.env._X_AMZN_TRACE_ID
 
 function consoleLog(str) {
   process.stderr.write(formatConsole(str))
@@ -70,6 +71,8 @@ var OPTIONS = {
 
 // Some weird spelling error in the source?
 OPTIONS.invokeid = OPTIONS.invokeId
+
+OPTIONS['x-amzn-trace-id'] = XRAY_TRACE_ID
 
 var invoked = false
 var errored = false

--- a/nodejs8.10/run/awslambda-mock.js
+++ b/nodejs8.10/run/awslambda-mock.js
@@ -15,6 +15,7 @@ var ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'SOME_ACCESS_KEY_ID'
 var SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'SOME_SECRET_ACCESS_KEY'
 var SESSION_TOKEN = process.env.AWS_SESSION_TOKEN
 var INVOKED_ARN = process.env.AWS_LAMBDA_FUNCTION_INVOKED_ARN || arn(REGION, ACCOUNT_ID, FN_NAME)
+var XRAY_TRACE_ID = process.env._X_AMZN_TRACE_ID
 
 function consoleLog(str) {
   process.stderr.write(formatConsole(str))
@@ -70,6 +71,8 @@ var OPTIONS = {
 
 // Some weird spelling error in the source?
 OPTIONS.invokeid = OPTIONS.invokeId
+
+OPTIONS['x-amzn-trace-id'] = XRAY_TRACE_ID
 
 var invoked = false
 var errored = false


### PR DESCRIPTION
## Issue
Passing `_X_AMZN_TRACE_ID` as an extra docker environment variable for nodejs runtimes `4.3`, `6.10` & `8.10` does not work. The `_X_AMZN_TRACE_ID` environment variable and its value won't be available inside the invoked lambda function.

On the other hand, it works when using `python2.7` & `python3.6` runtimes. Other runtimes were not tested.

## Cause
https://github.com/lambci/docker-lambda/blob/1615cce850c7d1eb9f0c8e4446e649ae6c5122cd/nodejs8.10/run/Dockerfile#L7-L11

Inside `https://lambci.s3.amazonaws.com/fs/nodejs8.10.tgz` then `/var/runtime/node_modules/awslambda/index.js` in `InvokeManager.start` the `_X_AMZN_TRACE_ID` is deleted from the environment variables if `x-amzn-trace-id` is not set.

```
        if(options['x-amzn-trace-id'] !== undefined) {
            process.env['_X_AMZN_TRACE_ID'] = options['x-amzn-trace-id'];
        } else {
            delete process.env['_X_AMZN_TRACE_ID'];
        }
```

## Fix

Use `awslambda-mock.js` to set `x-amzn-trace-id` from the docker environment variables.

### Fix preview
https://hub.docker.com/r/tanbouz/docker-lambda/tags/

Source: https://github.com/Tanbouz/docker-lambda/commits/xray

Python runtimes were not modified, just for testing.

## Use case

X-Ray support for SAM CLI https://github.com/awslabs/aws-sam-cli/pull/737

Thank you 😊 