### PR TITLE
Add debugging support.  Minor refactoring

### DIFF
--- a/dotnetcore2.0/run/MockBootstraps/DebuggerExtensions.cs
+++ b/dotnetcore2.0/run/MockBootstraps/DebuggerExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace MockLambdaRuntime
+{
+    internal static class DebuggerExtensions
+    {
+        /// <summary>
+        /// Tries to wait for the debugger to attach by inspecting <see cref="Debugger.IsAttached"/> property in a loop.
+        /// </summary>
+        /// <param name="queryInterval"><see cref="TimeSpan"/> representing the frequency of inspection.</param>
+        /// <param name="timeout"><see cref="TimeSpan"/> representing the timeout for the operation.</param>
+        /// <returns><c>True</c> if debugger was attached, false if timeout occured.</returns>
+        public static bool TryWaitForAttaching(TimeSpan queryInterval, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            while (!Debugger.IsAttached)
+            {
+                if (stopwatch.Elapsed > timeout)
+                {
+                    return false;
+                }
+
+                Task.Delay(queryInterval).Wait();
+            }
+
+            return true;
+        }
+    }
+}

--- a/dotnetcore2.0/run/MockBootstraps/MockLambdaContext.cs
+++ b/dotnetcore2.0/run/MockBootstraps/MockLambdaContext.cs
@@ -5,12 +5,12 @@ using System.Text;
 
 namespace MockLambdaRuntime
 {
-    public class MockLambdaContext
+    internal sealed class MockLambdaContext
     {
-        static readonly Random random = new Random();
+        private static readonly Random _random = new Random();
 
         /// Creates a mock context from a given Lambda handler and event
-        public MockLambdaContext(string handler, string eventBody)
+        internal MockLambdaContext(string handler, string eventBody)
         {
             RequestId = Guid.NewGuid().ToString();
             StartTime = DateTime.Now;
@@ -38,6 +38,7 @@ namespace MockLambdaRuntime
         }
 
         public long Duration => (long)(DateTime.Now - StartTime).TotalMilliseconds;
+
         public long BilledDuration => (long)(Math.Ceiling((DateTime.Now - StartTime).TotalMilliseconds / 100)) * 100;
 
         public long MemoryUsed => Process.GetCurrentProcess().WorkingSet64;
@@ -59,6 +60,7 @@ namespace MockLambdaRuntime
         }
 
         public string RequestId { get; }
+
         public DateTime StartTime { get; }
 
         public int Timeout => Convert.ToInt32(EnvHelper.GetOrDefault("AWS_LAMBDA_FUNCTION_TIMEOUT", "300"));
@@ -79,6 +81,6 @@ namespace MockLambdaRuntime
 
         public string Arn => EnvHelper.GetOrDefault("AWS_LAMBDA_FUNCTION_INVOKED_ARN", $"arn:aws:lambda:{Region}:{AccountId}:function:{FunctionName}");
 
-        string RandomLogStreamName => $"{DateTime.Now.ToString("yyyy/MM/dd")}/[{FunctionVersion}]{random.Next().ToString("x") + random.Next().ToString("x")}";
+        string RandomLogStreamName => $"{DateTime.Now.ToString("yyyy/MM/dd")}/[{FunctionVersion}]{_random.Next().ToString("x") + _random.Next().ToString("x")}";
     }
 }

--- a/dotnetcore2.1/run/MockBootstraps/DebuggerExtensions.cs
+++ b/dotnetcore2.1/run/MockBootstraps/DebuggerExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace MockLambdaRuntime
+{
+    internal static class DebuggerExtensions
+    {
+        /// <summary>
+        /// Tries to wait for the debugger to attach by inspecting <see cref="Debugger.IsAttached"/> property in a loop.
+        /// </summary>
+        /// <param name="queryInterval"><see cref="TimeSpan"/> representing the frequency of inspection.</param>
+        /// <param name="timeout"><see cref="TimeSpan"/> representing the timeout for the operation.</param>
+        /// <returns><c>True</c> if debugger was attached, false if timeout occured.</returns>
+        public static bool TryWaitForAttaching(TimeSpan queryInterval, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            while (!Debugger.IsAttached)
+            {
+                if (stopwatch.Elapsed > timeout)
+                {
+                    return false;
+                }
+
+                Task.Delay(queryInterval).Wait();
+            }
+
+            return true;
+        }
+    }
+}

--- a/dotnetcore2.1/run/MockBootstraps/MockLambdaContext.cs
+++ b/dotnetcore2.1/run/MockBootstraps/MockLambdaContext.cs
@@ -81,6 +81,6 @@ namespace MockLambdaRuntime
 
         public string Arn => EnvHelper.GetOrDefault("AWS_LAMBDA_FUNCTION_INVOKED_ARN", $"arn:aws:lambda:{Region}:{AccountId}:function:{FunctionName}");
 
-        string RandomLogStreamName => $"{DateTime.Now.ToString("yyyy/MM/dd")}/[{FunctionVersion}]{_random.Next().ToString("x") + _random.Next().ToString("x")}";
+        public string RandomLogStreamName => $"{DateTime.Now.ToString("yyyy/MM/dd")}/[{FunctionVersion}]{_random.Next().ToString("x") + _random.Next().ToString("x")}";
     }
 }

--- a/dotnetcore2.1/run/MockBootstraps/MockLambdaContext.cs
+++ b/dotnetcore2.1/run/MockBootstraps/MockLambdaContext.cs
@@ -5,12 +5,12 @@ using System.Text;
 
 namespace MockLambdaRuntime
 {
-    public class MockLambdaContext
+    internal sealed class MockLambdaContext
     {
-        static readonly Random random = new Random();
+        private static readonly Random _random = new Random();
 
         /// Creates a mock context from a given Lambda handler and event
-        public MockLambdaContext(string handler, string eventBody)
+        internal MockLambdaContext(string handler, string eventBody)
         {
             RequestId = Guid.NewGuid().ToString();
             StartTime = DateTime.Now;
@@ -38,6 +38,7 @@ namespace MockLambdaRuntime
         }
 
         public long Duration => (long)(DateTime.Now - StartTime).TotalMilliseconds;
+
         public long BilledDuration => (long)(Math.Ceiling((DateTime.Now - StartTime).TotalMilliseconds / 100)) * 100;
 
         public long MemoryUsed => Process.GetCurrentProcess().WorkingSet64;
@@ -59,6 +60,7 @@ namespace MockLambdaRuntime
         }
 
         public string RequestId { get; }
+
         public DateTime StartTime { get; }
 
         public int Timeout => Convert.ToInt32(EnvHelper.GetOrDefault("AWS_LAMBDA_FUNCTION_TIMEOUT", "300"));
@@ -79,6 +81,6 @@ namespace MockLambdaRuntime
 
         public string Arn => EnvHelper.GetOrDefault("AWS_LAMBDA_FUNCTION_INVOKED_ARN", $"arn:aws:lambda:{Region}:{AccountId}:function:{FunctionName}");
 
-        string RandomLogStreamName => $"{DateTime.Now.ToString("yyyy/MM/dd")}/[{FunctionVersion}]{random.Next().ToString("x") + random.Next().ToString("x")}";
+        string RandomLogStreamName => $"{DateTime.Now.ToString("yyyy/MM/dd")}/[{FunctionVersion}]{_random.Next().ToString("x") + _random.Next().ToString("x")}";
     }
 }


### PR DESCRIPTION
Hi, @mhart please take a look at this!

This PR takes a required step towards the ability to debug .NET Core application [issue](https://github.com/awslabs/aws-sam-cli/issues/568);

It adds additional optional flag `-d` and a known environment variable `_SHOULD_WAIT_FOR_DEBUGGER` if any of these is set Lambda will halt the execution until the debugger is attached.  Apart from that this PR formats code style for access modifiers.

We have an [issue](https://github.com/lambci/docker-lambda/issues/125) in this repo also. This PR, takes the most lightweight approach and does not touch the Dockerfiles at all.