### PR TITLE
Adding AWS Lambda Builders library to Build images

### DIFF
--- a/base/build/Dockerfile
+++ b/base/build/Dockerfile
@@ -24,3 +24,6 @@ f.close();" && \
   rm -rf /var/cache/yum /var/lib/rpm/__db.* && \
   > /var/log/yum.log
 
+RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python &&  \
+    pip install -U pip setuptools --no-cache-dir && \
+    pip install aws-lambda-builders==0.0.1-dev


### PR DESCRIPTION
I am working on adding a [`sam build`](https://github.com/awslabs/aws-sam-cli/pull/743) command to AWS SAM CLI.  As part of this, I created a separated project called [aws-lambda-builders](https://github.com/awslabs/aws-lambda-builders ) that contains a collection of builder workflows for various programming languages + dependency manager combinations. We have already implemented Python+PIP. We are in the process of adding support for other languages. My goal is to work with the community and add support in this library to build Lambda functions written in many combination of Programming Language (ex: Python) + DependencyManager (ex: PIP) + ApplicationFramework (Ex: Chalice).
 
I want to contribute to the Docker-Lambda build container by adding the “Lambda Builders” library into it. This library has a CLI wrapper that will allow customers to directly run a build inside the container using one of the built-in workflows without writing scripts. `sam build` command will also use this container to perform higher-fidelity builds.

This PR adds it the library to the base build image. For now I am using a development preview version `0.0.1-dev` to the images build fine. But I hope to release a stable 0.1.0 version soon which we can release to Dockerhub with.