### PR TITLE
Upgrading AWS Lambda Builders to v0.0.2

### DIFF
--- a/dotnetcore2.0/build/Dockerfile
+++ b/dotnetcore2.0/build/Dockerfile
@@ -19,6 +19,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir
 
 CMD ["dotnet", "build"]

--- a/dotnetcore2.1/build/Dockerfile
+++ b/dotnetcore2.1/build/Dockerfile
@@ -19,6 +19,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir
 
 CMD ["dotnet", "build"]

--- a/go1.x/build/Dockerfile
+++ b/go1.x/build/Dockerfile
@@ -16,6 +16,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir
 
 CMD ["dep", "ensure"]

--- a/java8/build/Dockerfile
+++ b/java8/build/Dockerfile
@@ -10,4 +10,4 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir

--- a/nodejs4.3/build/Dockerfile
+++ b/nodejs4.3/build/Dockerfile
@@ -11,6 +11,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir
 
 CMD ["npm", "rebuild"]

--- a/nodejs6.10/build/Dockerfile
+++ b/nodejs6.10/build/Dockerfile
@@ -11,6 +11,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir
 
 CMD ["npm", "rebuild"]

--- a/nodejs8.10/build/Dockerfile
+++ b/nodejs8.10/build/Dockerfile
@@ -11,6 +11,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir
 
 CMD ["npm", "rebuild"]

--- a/python2.7/build/Dockerfile
+++ b/python2.7/build/Dockerfile
@@ -9,4 +9,4 @@ RUN rm -rf /var/runtime /var/lang && \
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
   pip install -U virtualenv pipenv --no-cache-dir && \
-  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir

--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -20,4 +20,4 @@ RUN rm -rf /var/runtime /var/lang && \
 # Add these as a separate layer as they get updated frequently
 RUN pip install -U pip setuptools --no-cache-dir && \
   pip install -U virtualenv pipenv --no-cache-dir && \
-  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.1-dev --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli aws-lambda-builders==0.0.2 --no-cache-dir


### PR DESCRIPTION
Upgrading from a development release to a stable release of AWS Lambda Builders 