### PR TITLE
Wait for debugger flag for .NET Core 2.0 / 2.1 implementation

### DIFF
--- a/dotnetcore2.0/run/MockBootstraps/DebuggerExtensions.cs
+++ b/dotnetcore2.0/run/MockBootstraps/DebuggerExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace MockLambdaRuntime
+{
+    internal static class DebuggerExtensions
+    {
+        /// <summary>
+        /// Tries to wait for the debugger to attach by inspecting <see cref="Debugger.IsAttached"/> property in a loop.
+        /// </summary>
+        /// <param name="queryInterval"><see cref="TimeSpan"/> representing the frequency of inspection.</param>
+        /// <param name="timeout"><see cref="TimeSpan"/> representing the timeout for the operation.</param>
+        /// <returns><c>True</c> if debugger was attached, false if timeout occured.</returns>
+        public static bool TryWaitForAttaching(TimeSpan queryInterval, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            while (!Debugger.IsAttached)
+            {
+                if (stopwatch.Elapsed > timeout)
+                {
+                    return false;
+                }
+
+                Task.Delay(queryInterval).Wait();
+            }
+
+            return true;
+        }
+    }
+}

--- a/dotnetcore2.0/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.0/run/MockBootstraps/Program.cs
@@ -151,7 +151,7 @@ namespace MockLambdaRuntime
         static string GetEventBody(string[] args)
         {
             return args.Length > 1 ? args[1] : (Environment.GetEnvironmentVariable("AWS_LAMBDA_EVENT_BODY") ??
-              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "'{}'"));
+              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "{}"));
         }
     }
 

--- a/dotnetcore2.0/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.0/run/MockBootstraps/Program.cs
@@ -10,7 +10,7 @@ namespace MockLambdaRuntime
 {
     class Program
     {
-        private const string WaitForDebuggerFlag = "-d";
+        private const string WaitForDebuggerFlag = "--debugger-spin-wait";
         private const bool WaitForDebuggerFlagDefaultValue = false;
 
         /// Task root of lambda task

--- a/dotnetcore2.0/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.0/run/MockBootstraps/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -9,50 +11,80 @@ namespace MockLambdaRuntime
 {
     class Program
     {
+        private const string WaitForDebuggerFlagName = "d";
+        private const bool WaitForDebuggerFlagDefaultValue = false;
+
         /// Task root of lambda task
         static string lambdaTaskRoot = EnvHelper.GetOrDefault("LAMBDA_TASK_ROOT", "/var/task");
+
+        private static readonly TimeSpan _debuggerStatusQueryInterval = TimeSpan.FromMilliseconds(50);
+        private static readonly TimeSpan _debuggerStatusQueryTimeout = TimeSpan.FromMinutes(10);
 
         /// Program entry point
         static void Main(string[] args)
         {
             AssemblyLoadContext.Default.Resolving += OnAssemblyResolving;
 
-            var handler = GetFunctionHandler(args);
-            var body = GetEventBody(args);
-
-            var lambdaContext = new MockLambdaContext(handler, body);
-
-            var userCodeLoader = new UserCodeLoader(handler, InternalLogger.NO_OP_LOGGER);
-            userCodeLoader.Init(Console.Error.WriteLine);
-
-            var lambdaContextInternal = new LambdaContextInternal(lambdaContext.RemainingTime,
-                                                                  LogAction, new Lazy<CognitoClientContextInternal>(),
-                                                                  lambdaContext.RequestId,
-                                                                  new Lazy<string>(lambdaContext.Arn),
-                                                                  new Lazy<string>(string.Empty),
-                                                                  new Lazy<string>(string.Empty),
-                                                                  Environment.GetEnvironmentVariables());
-
-            Exception lambdaException = null;
-
-            LogRequestStart(lambdaContext);
             try
             {
-                userCodeLoader.Invoke(lambdaContext.InputStream, lambdaContext.OutputStream, lambdaContextInternal);
+                var shouldWaitForDebugger = GetShouldWaitForDebuggerFlag(args, out var positionalArgs);
+
+                var handler = GetFunctionHandler(positionalArgs);
+                var body = GetEventBody(positionalArgs);
+
+                if (shouldWaitForDebugger)
+                {
+                    TryDisplayProcessId();
+                    Console.Error.WriteLine("Waiting for the debugger to attach...");
+
+                    if (!DebuggerExtensions.TryWaitForAttaching(
+                        _debuggerStatusQueryInterval,
+                        _debuggerStatusQueryTimeout))
+                    {
+                        Console.Error.WriteLine("Timeout. Proceeding without debugger.");
+                    }
+                }
+
+                var lambdaContext = new MockLambdaContext(handler, body);
+
+                var userCodeLoader = new UserCodeLoader(handler, InternalLogger.NO_OP_LOGGER);
+                userCodeLoader.Init(Console.Error.WriteLine);
+
+                var lambdaContextInternal = new LambdaContextInternal(lambdaContext.RemainingTime,
+                                                                      LogAction, new Lazy<CognitoClientContextInternal>(),
+                                                                      lambdaContext.RequestId,
+                                                                      new Lazy<string>(lambdaContext.Arn),
+                                                                      new Lazy<string>(string.Empty),
+                                                                      new Lazy<string>(string.Empty),
+                                                                      Environment.GetEnvironmentVariables());
+
+                Exception lambdaException = null;
+
+                LogRequestStart(lambdaContext);
+                try
+                {
+                    userCodeLoader.Invoke(lambdaContext.InputStream, lambdaContext.OutputStream, lambdaContextInternal);
+                }
+                catch (Exception ex)
+                {
+                    lambdaException = ex;
+                }
+                LogRequestEnd(lambdaContext);
+
+                if (lambdaException == null)
+                {
+                    Console.WriteLine(lambdaContext.OutputText);
+                }
+                else
+                {
+                    Console.Error.WriteLine(lambdaException);
+                }
             }
+
+            // Catch all unhandled exceptions from runtime, to prevent user from hanging on them while debugging
             catch (Exception ex)
             {
-                lambdaException = ex;
-            }
-            LogRequestEnd(lambdaContext);
-
-            if (lambdaException == null)
-            {
-                Console.WriteLine(lambdaContext.OutputText);
-            }
-            else
-            {
-                Console.Error.WriteLine(lambdaException);
+                Console.Error.WriteLine($"\nUnhandled exception occured in runner:\n{ex}");
             }
         }
 
@@ -66,6 +98,60 @@ namespace MockLambdaRuntime
         private static void LogAction(string text)
         {
             Console.Error.WriteLine(text);
+        }
+
+        /// <summary>
+        /// Tries to display PID of the started program to simplify attaching.
+        /// </summary>
+        private static void TryDisplayProcessId()
+        {
+            try
+            {
+                var processId = Process.GetCurrentProcess().Id;
+
+                Console.Error.WriteLine($"Attach to process id: {processId}.");
+            }
+            catch (Exception ex) when (ex is InvalidOperationException || ex is PlatformNotSupportedException)
+            {
+                Console.Error.WriteLine($"Failed to get process id: {ex.Message}.");
+            }
+        }
+        /// <summary>
+        /// Extracts "waitForDebugger" flag from args. Returns other unprocessed arguments.
+        /// </summary>
+        /// <param name="args">Args to look through</param>
+        /// <param name="unprocessed">Arguments except for the "waitForDebugger" ones</param>
+        /// <returns>"waitForDebugger" flag value</returns>
+        private static bool GetShouldWaitForDebuggerFlag(string[] args, out string[] unprocessed)
+        {
+            var flagValue = WaitForDebuggerFlagDefaultValue;
+
+            var unprocessedList = new List<string>();
+
+            foreach (var argument in args)
+            {
+                if (argument.StartsWith('-'))
+                {
+                    var flag = argument.TrimStart('-');
+
+                    if (flag == WaitForDebuggerFlagName)
+                    {
+                        flagValue = true;
+                        continue;
+                    }
+                }
+
+                unprocessedList.Add(argument);
+            }
+
+            // Flag was not set from args, try environment variable
+            if (!flagValue)
+            {
+                flagValue = Environment.GetEnvironmentVariable("_SHOULD_WAIT_FOR_DEBUGGER") != null;
+            }
+
+            unprocessed = unprocessedList.ToArray();
+            return flagValue;
         }
 
         static void LogRequestStart(MockLambdaContext context)
@@ -94,7 +180,7 @@ namespace MockLambdaRuntime
         static string GetEventBody(string[] args)
         {
             return args.Length > 1 ? args[1] : (Environment.GetEnvironmentVariable("AWS_LAMBDA_EVENT_BODY") ??
-              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "{}"));
+              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "'{}'"));
         }
     }
 

--- a/dotnetcore2.0/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.0/run/MockBootstraps/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -34,7 +33,6 @@ namespace MockLambdaRuntime
 
                 if (shouldWaitForDebugger)
                 {
-                    TryDisplayProcessId();
                     Console.Error.WriteLine("Waiting for the debugger to attach...");
 
                     if (!DebuggerExtensions.TryWaitForAttaching(
@@ -100,22 +98,6 @@ namespace MockLambdaRuntime
             Console.Error.WriteLine(text);
         }
 
-        /// <summary>
-        /// Tries to display PID of the started program to simplify attaching.
-        /// </summary>
-        private static void TryDisplayProcessId()
-        {
-            try
-            {
-                var processId = Process.GetCurrentProcess().Id;
-
-                Console.Error.WriteLine($"Attach to process id: {processId}.");
-            }
-            catch (Exception ex) when (ex is InvalidOperationException || ex is PlatformNotSupportedException)
-            {
-                Console.Error.WriteLine($"Failed to get process id: {ex.Message}.");
-            }
-        }
         /// <summary>
         /// Extracts "waitForDebugger" flag from args. Returns other unprocessed arguments.
         /// </summary>

--- a/dotnetcore2.0/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.0/run/MockBootstraps/Program.cs
@@ -11,7 +11,7 @@ namespace MockLambdaRuntime
 {
     class Program
     {
-        private const string WaitForDebuggerFlagName = "d";
+        private const string WaitForDebuggerFlag = "-d";
         private const bool WaitForDebuggerFlagDefaultValue = false;
 
         /// Task root of lambda task
@@ -130,24 +130,13 @@ namespace MockLambdaRuntime
 
             foreach (var argument in args)
             {
-                if (argument.StartsWith('-'))
+                if (argument == WaitForDebuggerFlag)
                 {
-                    var flag = argument.TrimStart('-');
-
-                    if (flag == WaitForDebuggerFlagName)
-                    {
-                        flagValue = true;
-                        continue;
-                    }
+                    flagValue = true;
+                    continue;
                 }
 
                 unprocessedList.Add(argument);
-            }
-
-            // Flag was not set from args, try environment variable
-            if (!flagValue)
-            {
-                flagValue = Environment.GetEnvironmentVariable("_SHOULD_WAIT_FOR_DEBUGGER") != null;
             }
 
             unprocessed = unprocessedList.ToArray();

--- a/dotnetcore2.1/run/MockBootstraps/DebuggerExtensions.cs
+++ b/dotnetcore2.1/run/MockBootstraps/DebuggerExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace MockLambdaRuntime
+{
+    internal static class DebuggerExtensions
+    {
+        /// <summary>
+        /// Tries to wait for the debugger to attach by inspecting <see cref="Debugger.IsAttached"/> property in a loop.
+        /// </summary>
+        /// <param name="queryInterval"><see cref="TimeSpan"/> representing the frequency of inspection.</param>
+        /// <param name="timeout"><see cref="TimeSpan"/> representing the timeout for the operation.</param>
+        /// <returns><c>True</c> if debugger was attached, false if timeout occured.</returns>
+        public static bool TryWaitForAttaching(TimeSpan queryInterval, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            while (!Debugger.IsAttached)
+            {
+                if (stopwatch.Elapsed > timeout)
+                {
+                    return false;
+                }
+
+                Task.Delay(queryInterval).Wait();
+            }
+
+            return true;
+        }
+    }
+}

--- a/dotnetcore2.1/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.1/run/MockBootstraps/Program.cs
@@ -151,7 +151,7 @@ namespace MockLambdaRuntime
         static string GetEventBody(string[] args)
         {
             return args.Length > 1 ? args[1] : (Environment.GetEnvironmentVariable("AWS_LAMBDA_EVENT_BODY") ??
-              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "'{}'"));
+              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "{}"));
         }
     }
 

--- a/dotnetcore2.1/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.1/run/MockBootstraps/Program.cs
@@ -10,7 +10,7 @@ namespace MockLambdaRuntime
 {
     class Program
     {
-        private const string WaitForDebuggerFlag = "-d";
+        private const string WaitForDebuggerFlag = "--debugger-spin-wait";
         private const bool WaitForDebuggerFlagDefaultValue = false;
 
         /// Task root of lambda task

--- a/dotnetcore2.1/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.1/run/MockBootstraps/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -9,50 +11,80 @@ namespace MockLambdaRuntime
 {
     class Program
     {
+        private const string WaitForDebuggerFlagName = "d";
+        private const bool WaitForDebuggerFlagDefaultValue = false;
+
         /// Task root of lambda task
         static string lambdaTaskRoot = EnvHelper.GetOrDefault("LAMBDA_TASK_ROOT", "/var/task");
+
+        private static readonly TimeSpan _debuggerStatusQueryInterval = TimeSpan.FromMilliseconds(50);
+        private static readonly TimeSpan _debuggerStatusQueryTimeout = TimeSpan.FromMinutes(10);
 
         /// Program entry point
         static void Main(string[] args)
         {
             AssemblyLoadContext.Default.Resolving += OnAssemblyResolving;
 
-            var handler = GetFunctionHandler(args);
-            var body = GetEventBody(args);
-
-            var lambdaContext = new MockLambdaContext(handler, body);
-
-            var userCodeLoader = new UserCodeLoader(handler, InternalLogger.NO_OP_LOGGER);
-            userCodeLoader.Init(Console.Error.WriteLine);
-
-            var lambdaContextInternal = new LambdaContextInternal(lambdaContext.RemainingTime,
-                                                                  LogAction, new Lazy<CognitoClientContextInternal>(),
-                                                                  lambdaContext.RequestId,
-                                                                  new Lazy<string>(lambdaContext.Arn),
-                                                                  new Lazy<string>(string.Empty),
-                                                                  new Lazy<string>(string.Empty),
-                                                                  Environment.GetEnvironmentVariables());
-
-            Exception lambdaException = null;
-
-            LogRequestStart(lambdaContext);
             try
             {
-                userCodeLoader.Invoke(lambdaContext.InputStream, lambdaContext.OutputStream, lambdaContextInternal);
+                var shouldWaitForDebugger = GetShouldWaitForDebuggerFlag(args, out var positionalArgs);
+
+                var handler = GetFunctionHandler(positionalArgs);
+                var body = GetEventBody(positionalArgs);
+
+                if (shouldWaitForDebugger)
+                {
+                    TryDisplayProcessId();
+                    Console.Error.WriteLine("Waiting for the debugger to attach...");
+
+                    if (!DebuggerExtensions.TryWaitForAttaching(
+                        _debuggerStatusQueryInterval,
+                        _debuggerStatusQueryTimeout))
+                    {
+                        Console.Error.WriteLine("Timeout. Proceeding without debugger.");
+                    }
+                }
+
+                var lambdaContext = new MockLambdaContext(handler, body);
+
+                var userCodeLoader = new UserCodeLoader(handler, InternalLogger.NO_OP_LOGGER);
+                userCodeLoader.Init(Console.Error.WriteLine);
+
+                var lambdaContextInternal = new LambdaContextInternal(lambdaContext.RemainingTime,
+                                                                      LogAction, new Lazy<CognitoClientContextInternal>(),
+                                                                      lambdaContext.RequestId,
+                                                                      new Lazy<string>(lambdaContext.Arn),
+                                                                      new Lazy<string>(string.Empty),
+                                                                      new Lazy<string>(string.Empty),
+                                                                      Environment.GetEnvironmentVariables());
+
+                Exception lambdaException = null;
+
+                LogRequestStart(lambdaContext);
+                try
+                {
+                    userCodeLoader.Invoke(lambdaContext.InputStream, lambdaContext.OutputStream, lambdaContextInternal);
+                }
+                catch (Exception ex)
+                {
+                    lambdaException = ex;
+                }
+                LogRequestEnd(lambdaContext);
+
+                if (lambdaException == null)
+                {
+                    Console.WriteLine(lambdaContext.OutputText);
+                }
+                else
+                {
+                    Console.Error.WriteLine(lambdaException);
+                }
             }
+
+            // Catch all unhandled exceptions from runtime, to prevent user from hanging on them while debugging
             catch (Exception ex)
             {
-                lambdaException = ex;
-            }
-            LogRequestEnd(lambdaContext);
-
-            if (lambdaException == null)
-            {
-                Console.WriteLine(lambdaContext.OutputText);
-            }
-            else
-            {
-                Console.Error.WriteLine(lambdaException);
+                Console.Error.WriteLine($"\nUnhandled exception occured in runner:\n{ex}");
             }
         }
 
@@ -66,6 +98,60 @@ namespace MockLambdaRuntime
         private static void LogAction(string text)
         {
             Console.Error.WriteLine(text);
+        }
+
+        /// <summary>
+        /// Tries to display PID of the started program to simplify attaching.
+        /// </summary>
+        private static void TryDisplayProcessId()
+        {
+            try
+            {
+                var processId = Process.GetCurrentProcess().Id;
+
+                Console.Error.WriteLine($"Attach to process id: {processId}.");
+            }
+            catch (Exception ex) when (ex is InvalidOperationException || ex is PlatformNotSupportedException)
+            {
+                Console.Error.WriteLine($"Failed to get process id: {ex.Message}.");
+            }
+        }
+        /// <summary>
+        /// Extracts "waitForDebugger" flag from args. Returns other unprocessed arguments.
+        /// </summary>
+        /// <param name="args">Args to look through</param>
+        /// <param name="unprocessed">Arguments except for the "waitForDebugger" ones</param>
+        /// <returns>"waitForDebugger" flag value</returns>
+        private static bool GetShouldWaitForDebuggerFlag(string[] args, out string[] unprocessed)
+        {
+            var flagValue = WaitForDebuggerFlagDefaultValue;
+
+            var unprocessedList = new List<string>();
+
+            foreach (var argument in args)
+            {
+                if (argument.StartsWith('-'))
+                {
+                    var flag = argument.TrimStart('-');
+
+                    if (flag == WaitForDebuggerFlagName)
+                    {
+                        flagValue = true;
+                        continue;
+                    }
+                }
+
+                unprocessedList.Add(argument);
+            }
+
+            // Flag was not set from args, try environment variable
+            if (!flagValue)
+            {
+                flagValue = Environment.GetEnvironmentVariable("_SHOULD_WAIT_FOR_DEBUGGER") != null;
+            }
+
+            unprocessed = unprocessedList.ToArray();
+            return flagValue;
         }
 
         static void LogRequestStart(MockLambdaContext context)
@@ -94,7 +180,7 @@ namespace MockLambdaRuntime
         static string GetEventBody(string[] args)
         {
             return args.Length > 1 ? args[1] : (Environment.GetEnvironmentVariable("AWS_LAMBDA_EVENT_BODY") ??
-              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "{}"));
+              (Environment.GetEnvironmentVariable("DOCKER_LAMBDA_USE_STDIN") != null ? Console.In.ReadToEnd() : "'{}'"));
         }
     }
 

--- a/dotnetcore2.1/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.1/run/MockBootstraps/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -34,7 +33,6 @@ namespace MockLambdaRuntime
 
                 if (shouldWaitForDebugger)
                 {
-                    TryDisplayProcessId();
                     Console.Error.WriteLine("Waiting for the debugger to attach...");
 
                     if (!DebuggerExtensions.TryWaitForAttaching(
@@ -100,22 +98,6 @@ namespace MockLambdaRuntime
             Console.Error.WriteLine(text);
         }
 
-        /// <summary>
-        /// Tries to display PID of the started program to simplify attaching.
-        /// </summary>
-        private static void TryDisplayProcessId()
-        {
-            try
-            {
-                var processId = Process.GetCurrentProcess().Id;
-
-                Console.Error.WriteLine($"Attach to process id: {processId}.");
-            }
-            catch (Exception ex) when (ex is InvalidOperationException || ex is PlatformNotSupportedException)
-            {
-                Console.Error.WriteLine($"Failed to get process id: {ex.Message}.");
-            }
-        }
         /// <summary>
         /// Extracts "waitForDebugger" flag from args. Returns other unprocessed arguments.
         /// </summary>

--- a/dotnetcore2.1/run/MockBootstraps/Program.cs
+++ b/dotnetcore2.1/run/MockBootstraps/Program.cs
@@ -11,7 +11,7 @@ namespace MockLambdaRuntime
 {
     class Program
     {
-        private const string WaitForDebuggerFlagName = "d";
+        private const string WaitForDebuggerFlag = "-d";
         private const bool WaitForDebuggerFlagDefaultValue = false;
 
         /// Task root of lambda task
@@ -130,24 +130,13 @@ namespace MockLambdaRuntime
 
             foreach (var argument in args)
             {
-                if (argument.StartsWith('-'))
+                if (argument == WaitForDebuggerFlag)
                 {
-                    var flag = argument.TrimStart('-');
-
-                    if (flag == WaitForDebuggerFlagName)
-                    {
-                        flagValue = true;
-                        continue;
-                    }
+                    flagValue = true;
+                    continue;
                 }
 
                 unprocessedList.Add(argument);
-            }
-
-            // Flag was not set from args, try environment variable
-            if (!flagValue)
-            {
-                flagValue = Environment.GetEnvironmentVariable("_SHOULD_WAIT_FOR_DEBUGGER") != null;
             }
 
             unprocessed = unprocessedList.ToArray();


### PR DESCRIPTION
## Original issue

#125 - issue, that requests .NET Core 2.0 / 2.1 debugging support

### Changes

* Added `DebuggerExtensions` class which enables waiting for the debugger to attach in the loop, inspecting `Debugger.IsAttached` property with interval (50ms). Also it has 10 minutes timeout, after it, function will continue executing without debugging;
* Added `--debugger-spin-wait` flag handling, if it supplied as an argument, then, we will use `DebuggerExtensions.TryWaitForAttaching` to wait for the debugger before proceeding to execution;
* Added `try / catch` block for all body of `Main` to prevent user from hanging on `External Code Exception` while debugging.

### Side note

I've closed #127 as it had a lot of unnecessary stuff. Now this PR has only required changes, to proceed with #125. 