### PR TITLE
Bump Delve debugger API in Go Lambda container to version 2

### DIFF
--- a/go1.x/run/aws-lambda-mock.go
+++ b/go1.x/run/aws-lambda-mock.go
@@ -85,7 +85,7 @@ func main() {
 		delveArgs := []string{
 			"--listen=:" + *delvePort,
 			"--headless=true",
-			"--api-version=1",
+			"--api-version=2",
 			"--log",
 			"exec",
 			"/var/task/" + handler,


### PR DESCRIPTION
At the time of introducing Delve debugger in Go Lambda containers (#97) Visual Studio Code supported only version 1 of it - [that was the reason for setting it](https://github.com/lambci/docker-lambda/pull/97#issuecomment-436290438). Later on IntelliJ IDEs introduced remote debugging for Go but for Delve API in version 2 and VSC too. Now debugging Go containers is possible only in VSC because there you can [choose version it is using (and what's more, default is 2)](https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code#set-up-configurations-in-your-settings). Running debugger with version 2 will make debugging be possible in IntelliJ IDEs and debugging more configurable in VSC.

![image](https://user-images.githubusercontent.com/23511767/48822790-8c382a80-ed5e-11e8-9a70-63cfc7345772.png)