### PR TITLE
Use --document option instead of --ri and --rdoc

### DIFF
--- a/ruby2.5/build/Dockerfile
+++ b/ruby2.5/build/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -rf /var/runtime /var/lang /var/rapid && \
   curl https://lambci.s3.amazonaws.com/fs/ruby2.5.tgz | tar -zx -C /
 
 # Add these as a separate layer as they get updated frequently
-RUN gem update --system --no-ri --no-rdoc && \
-  gem install --no-ri --no-rdoc bundler && \
+RUN gem update --system --no-document && \
+  gem install --no-document bundler && \
   curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
   pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir


### PR DESCRIPTION
Hi, I'm the maintainer of RubyGems. We are removing `--no-ri` and `--no-rdoc` options at RubyGems 3.0. Please use `--no-document` instead of them.