### PR TITLE
Upgrading AWS Lambda Builders to v0.0.5

### DIFF
--- a/dotnetcore2.0/build/Dockerfile
+++ b/dotnetcore2.0/build/Dockerfile
@@ -19,6 +19,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir
 
 CMD ["dotnet", "build"]

--- a/dotnetcore2.1/build/Dockerfile
+++ b/dotnetcore2.1/build/Dockerfile
@@ -19,6 +19,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir
 
 CMD ["dotnet", "build"]

--- a/go1.x/build/Dockerfile
+++ b/go1.x/build/Dockerfile
@@ -16,6 +16,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir
 
 CMD ["dep", "ensure"]

--- a/java8/build/Dockerfile
+++ b/java8/build/Dockerfile
@@ -10,4 +10,4 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir

--- a/nodejs4.3/build/Dockerfile
+++ b/nodejs4.3/build/Dockerfile
@@ -11,6 +11,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir
 
 CMD ["npm", "rebuild"]

--- a/nodejs6.10/build/Dockerfile
+++ b/nodejs6.10/build/Dockerfile
@@ -11,6 +11,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir
 
 CMD ["npm", "rebuild"]

--- a/nodejs8.10/build/Dockerfile
+++ b/nodejs8.10/build/Dockerfile
@@ -11,6 +11,6 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir
 
 CMD ["npm", "rebuild"]

--- a/provided/build/Dockerfile
+++ b/provided/build/Dockerfile
@@ -2,4 +2,4 @@ FROM lambci/lambda-base:build
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir

--- a/python2.7/build/Dockerfile
+++ b/python2.7/build/Dockerfile
@@ -9,4 +9,4 @@ RUN rm -rf /var/runtime /var/lang && \
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
   pip install -U virtualenv pipenv --no-cache-dir && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir

--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -20,4 +20,4 @@ RUN rm -rf /var/runtime /var/lang && \
 # Add these as a separate layer as they get updated frequently
 RUN pip install -U pip setuptools --no-cache-dir && \
   pip install -U virtualenv pipenv --no-cache-dir && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir

--- a/python3.7/build/Dockerfile
+++ b/python3.7/build/Dockerfile
@@ -12,4 +12,4 @@ RUN rm -rf /var/runtime /var/lang /var/rapid && \
 # Add these as a separate layer as they get updated frequently
 RUN pip install -U pip setuptools --no-cache-dir && \
   pip install -U virtualenv pipenv --no-cache-dir && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir

--- a/ruby2.5/build/Dockerfile
+++ b/ruby2.5/build/Dockerfile
@@ -14,4 +14,4 @@ RUN rm -rf /var/runtime /var/lang /var/rapid && \
 RUN gem update --system --no-document && \
   gem install --no-document bundler && \
   curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.4 --no-cache-dir
+  pip install -U awscli boto3 aws-sam-cli==0.9.0 aws-lambda-builders==0.0.5 --no-cache-dir


### PR DESCRIPTION
This version supports building Ruby functions through bundler.

Release notes: https://github.com/awslabs/aws-lambda-builders/releases/tag/v0.0.5