### PR TITLE
Updated bootstrap path ordering

### DIFF
--- a/provided/run/init.go
+++ b/provided/run/init.go
@@ -102,11 +102,11 @@ func main() {
 
 	cmdPath := *bootstrapPath
 	if _, err := os.Stat(cmdPath); os.IsNotExist(err) {
-		cmdPath = "/var/task/bootstrap"
+		cmdPath = "/opt/bootstrap"
 		if _, err := os.Stat(cmdPath); os.IsNotExist(err) {
-			cmdPath = "/opt/bootstrap"
+			cmdPath = "/var/task/bootstrap"
 			if _, err := os.Stat(cmdPath); os.IsNotExist(err) {
-				abortRequest(fmt.Errorf("Couldn't find valid bootstrap(s): [/var/task/bootstrap /opt/bootstrap]"))
+				abortRequest(fmt.Errorf("Couldn't find valid bootstrap(s): [/opt/bootstrap /var/task/bootstrap]"))
 				return
 			}
 		}


### PR DESCRIPTION
Updated the ordering of the bootstrap path checks to check /opt first, allowing code containing a bootstrap folder to run correctly.

Fixes #152 (I think).