### PR TITLE
Bump go version to 1.11.5 in build image

### DIFF
--- a/go1.x/build/Dockerfile
+++ b/go1.x/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM lambci/lambda-base:build
 
-ENV GOLANG_VERSION=1.11.2 \
+ENV GOLANG_VERSION=1.11.5 \
     GOPATH=/go \
     PATH=/go/bin:/usr/local/go/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_go1.x


### PR DESCRIPTION
Just bumping to the go build image to the latest version.