### PR TITLE
bump Go debugger Delve API via flags

### DIFF
--- a/go1.x/run/aws-lambda-mock.go
+++ b/go1.x/run/aws-lambda-mock.go
@@ -28,6 +28,7 @@ func main() {
 	debugMode := flag.Bool("debug", false, "enables delve debugging")
 	delvePath := flag.String("delvePath", "/tmp/lambci_debug_files/dlv", "path to delve")
 	delvePort := flag.String("delvePort", "5985", "port to start delve server on")
+	delveAPI  := flag.String("delveAPI", "1", "delve api version")
 	flag.Parse()
 	positionalArgs := flag.Args()
 	var handler string
@@ -85,7 +86,7 @@ func main() {
 		delveArgs := []string{
 			"--listen=:" + *delvePort,
 			"--headless=true",
-			"--api-version=1",
+			"--api-version=" + *delveAPI,
 			"--log",
 			"exec",
 			"/var/task/" + handler,


### PR DESCRIPTION
Configure Delve API version via flags, which has a default value of '1' for backwards compatibility.

There is now a lot of interest in running the Delve debugger with API version **'2'** [Debugging go functions works with VS Code but not Goland](https://github.com/awslabs/aws-sam-cli/issues/886).

We are all now aware VSC and other IDEs support this newer Devle API version.

This pull request is addressing the out-standing comments left within the PR (#131) raised, which have been unaddressed for 3+ months. 