### PR TITLE
Install Amazon Lambda Global Tools by Default

### DIFF
--- a/dotnetcore2.1/build/Dockerfile
+++ b/dotnetcore2.1/build/Dockerfile
@@ -21,6 +21,7 @@ RUN rm -rf /var/runtime /var/lang && \
 
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
-  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli==0.16.0 aws-lambda-builders==0.3.0 --no-cache-dir
+  pip install -U virtualenv pipenv awscli boto3 aws-sam-cli==0.16.0 aws-lambda-builders==0.3.0 --no-cache-dir && \
+  dotnet tool install --global Amazon.Lambda.Tools --version 3.2.3
 
 CMD ["dotnet", "build"]


### PR DESCRIPTION
...and also correct a bug related to setting the environment

Fixes bug introduced in https://github.com/lambci/docker-lambda/pull/156.