### PR TITLE
Fix Node v4.3 entrypoint

### DIFF
--- a/base/native-test.sh
+++ b/base/native-test.sh
@@ -22,8 +22,8 @@ CMD="BUILD_ONLY=true npm install --build-from-source \
 "
 
 docker run --rm \
-  -e PATH=/usr/local/lib64/node-v4.3.x/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin \
-  -e LD_LIBRARY_PATH=/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib \
+  -e PATH=/var/lang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin \
+  -e LD_LIBRARY_PATH=/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib \
   -e AWS_EXECUTION_ENV=AWS_Lambda_nodejs4.3 \
   -e NODE_PATH=/var/runtime:/var/task:/var/runtime/node_modules \
   -e npm_config_unsafe-perm=true \

--- a/nodejs4.3/run/Dockerfile
+++ b/nodejs4.3/run/Dockerfile
@@ -1,7 +1,7 @@
 FROM lambci/lambda-base
 
-ENV PATH=/usr/local/lib64/node-v4.3.x/bin:$PATH \
-    LD_LIBRARY_PATH=/usr/local/lib64/node-v4.3.x/lib:$LD_LIBRARY_PATH \
+ENV PATH=/var/lang/bin:$PATH \
+    LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_nodejs4.3 \
     NODE_PATH=/var/runtime:/var/task:/var/runtime/node_modules
 
@@ -12,6 +12,6 @@ COPY awslambda-mock.js /var/runtime/node_modules/awslambda/build/Release/awslamb
 
 USER sbx_user1051
 
-ENTRYPOINT ["/usr/local/lib64/node-v4.3.x/bin/node", "--expose-gc", "--max-executable-size=160", "--max-semi-space-size=150", "--max-old-space-size=2547", \
+ENTRYPOINT ["/var/lang/bin/node", "--expose-gc", "--max-executable-size=160", "--max-semi-space-size=150", "--max-old-space-size=2547", \
   "/var/runtime/node_modules/awslambda/index.js"]
 


### PR DESCRIPTION
## Context

I'm having issues running `node` in the Node v4.3 Docker image:

```shell
Fetching lambci/lambda:nodejs4.3 Docker container image......
2019-07-26 12:33:23 Mounting <PATH> as /var/task:ro,delegated inside runtime container
Traceback (most recent call last):
  File "/usr/local/bin/sam", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/samcli/commands/local/invoke/cli.py", line 56, in cli
    parameter_overrides)  # pragma: no cover
  File "/usr/local/lib/python2.7/site-packages/samcli/commands/local/invoke/cli.py", line 100, in do_cli
    stderr=context.stderr)
  File "/usr/local/lib/python2.7/site-packages/samcli/commands/local/lib/local_lambda.py", line 93, in invoke
    self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
  File "/usr/local/lib/python2.7/site-packages/samcli/local/lambdafn/runtime.py", line 86, in invoke
    self._container_manager.run(container)
  File "/usr/local/lib/python2.7/site-packages/samcli/local/docker/manager.py", line 98, in run
    container.start(input_data=input_data)
  File "/usr/local/lib/python2.7/site-packages/samcli/local/docker/container.py", line 189, in start
    real_container.start()
  File "/usr/local/lib/python2.7/site-packages/docker/models/containers.py", line 392, in start
    return self.client.api.start(self.id, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/docker/api/container.py", line 1091, in start
    self._raise_for_status(res)
  File "/usr/local/lib/python2.7/site-packages/docker/api/client.py", line 263, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/usr/local/lib/python2.7/site-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
docker.errors.APIError: 400 Client Error: Bad Request ("OCI runtime create failed: container_linux.go:344: starting container process caused "exec: \"/usr/local/lib64/node-v4.3.x/bin/node\": stat /usr/local/lib64/node-v4.3.x/bin/node: no such file or directory": unknown")
```

## Issue

`/usr/local/lib64/node-v4.3.x/bin/node` doesn't exist. `node` is found @ `/var/lang/bin/node` instead.

## Open Questions

I still see references to `/usr/local/lib64/node-v4.3.x/bin/node` in `base/dump-nodejs43.js`. Is there a way to update?

cc. @mhart 