### PR TITLE
Update Amazon.Lambda.Tools Version to Latest

### DIFF
--- a/dotnetcore2.1/build/Dockerfile
+++ b/dotnetcore2.1/build/Dockerfile
@@ -23,6 +23,6 @@ RUN rm -rf /var/runtime /var/lang && \
 # Add these as a separate layer as they get updated frequently
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
   pip install -U virtualenv pipenv awscli boto3 aws-sam-cli==0.19.0 aws-lambda-builders==0.3.0 --no-cache-dir && \
-  dotnet tool install --global Amazon.Lambda.Tools --version 3.2.3
+  dotnet tool install --global Amazon.Lambda.Tools --version 3.3.0
 
 CMD ["dotnet", "build"]


### PR DESCRIPTION
Some of my teams have reported that this drift is preventing the `sam build` command from working in their CI/CD scripts.