### PR TITLE
Add NODE_PATH to runtime container

### DIFF
--- a/nodejs10.x/run/Dockerfile
+++ b/nodejs10.x/run/Dockerfile
@@ -10,7 +10,8 @@ FROM lambci/lambda-base-2
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
-    AWS_EXECUTION_ENV=AWS_Lambda_nodejs10.x
+    AWS_EXECUTION_ENV=AWS_Lambda_nodejs10.x \
+    NODE_PATH=/opt/nodejs/node10/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
 COPY --from=0 /opt/* /var/
 


### PR DESCRIPTION
Just adding an env variable to the runtime container, same value as in the [build container](https://github.com/lambci/docker-lambda/blob/c9cb4faf572ce963ec5beff96fad24c57f79ecbe/nodejs10.x/build/Dockerfile#L6)

This is intended to fix an [issue](https://github.com/awslabs/aws-sam-cli/issues/1246) with running nodejs10.x containers in debug mode.