### PR TITLE
Update Golang version to 1.13.1 in builder Dockerfile

### DIFF
--- a/go1.x/build/Dockerfile
+++ b/go1.x/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM lambci/lambda-base:build
 
 # https://golang.org/doc/devel/release.html
-ENV GOLANG_VERSION=1.12.9 \
+ENV GOLANG_VERSION=1.13.1 \
     GOPATH=/go \
     PATH=/go/bin:/usr/local/go/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_go1.x


### PR DESCRIPTION
This pull request bumps up the Golang version from `1.12.9` to latest `1.13.1` for `lambci/lambda:build-go1.x`.