### PR TITLE
Cast header Lambda-Runtime-Deadline-Ms to int for Python2.7/3.6 runtimes

### DIFF
--- a/python2.7/run/runtime_mock.py
+++ b/python2.7/run/runtime_mock.py
@@ -184,7 +184,7 @@ def receive_invoke():
         raise
 
     INVOKEID = resp.getheader('Lambda-Runtime-Aws-Request-Id')
-    DEADLINE_MS = resp.getheader('Lambda-Runtime-Deadline-Ms')
+    DEADLINE_MS = int(resp.getheader('Lambda-Runtime-Deadline-Ms'))
     INVOKED_FUNCTION_ARN = resp.getheader(
         'Lambda-Runtime-Invoked-Function-Arn')
     XRAY_TRACE_ID = resp.getheader('Lambda-Runtime-Trace-Id')

--- a/python3.6/run/runtime_mock.py
+++ b/python3.6/run/runtime_mock.py
@@ -184,7 +184,7 @@ def receive_invoke():
         raise
 
     INVOKEID = resp.getheader('Lambda-Runtime-Aws-Request-Id')
-    DEADLINE_MS = resp.getheader('Lambda-Runtime-Deadline-Ms')
+    DEADLINE_MS = int(resp.getheader('Lambda-Runtime-Deadline-Ms'))
     INVOKED_FUNCTION_ARN = resp.getheader(
         'Lambda-Runtime-Invoked-Function-Arn')
     XRAY_TRACE_ID = resp.getheader('Lambda-Runtime-Trace-Id')


### PR DESCRIPTION
We are experiencing an issue with 2.7 runtime when calling `get_remaining_time_in_millis`. It appears that in the runtime the variable `DEADLINE_MS` is overwritten with a value pulled directly from a header, which is a string. Then when `get_remaining_time_in_millis` is called, it tries to subtract an int from a string, and so throws. This PR simply casts the received header value to an int before overwriting the variable.

Proof of bug:

```
"""
Save this to a file named lambda_function.py
 
Runs without problem in python 3.7
docker run --rm -v $PWD:/var/task lambci/lambda:python3.7 lambda_function.lambda_handler
 
Has problems in python 2.7 and 3.6
docker run --rm -v $PWD:/var/task lambci/lambda:python2.7 lambda_function.lambda_handler
docker run --rm -v $PWD:/var/task lambci/lambda:python3.6 lambda_function.lambda_handler
"""
 
def lambda_handler(event, context):
    # https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
    func_name = context.function_name
    rem_time_ms = context.get_remaining_time_in_millis()
 
    return {
        "func_name": func_name,
        "rem_time_ms": rem_time_ms,
    }
```