### PR TITLE
Add file watching

### DIFF
--- a/dotnetcore2.0/run/MockBootstraps/MockRuntime.cs
+++ b/dotnetcore2.0/run/MockBootstraps/MockRuntime.cs
@@ -109,7 +109,26 @@ namespace AWSLambda.Internal.Bootstrap
             {
                 logs = "";
             }
-            var result = client.GetAsync("http://127.0.0.1:9001/2018-06-01/runtime/invocation/next").Result;
+            HttpResponseMessage result = null;
+            try
+            {
+                result = client.GetAsync("http://127.0.0.1:9001/2018-06-01/runtime/invocation/next").Result;
+            }
+            catch (AggregateException ae)
+            {
+                if (ae.InnerException is HttpRequestException && ae.InnerException.InnerException != null &&
+                    (ae.InnerException.InnerException is SocketException ||
+                        // happens on dotnetcore2.0
+                        ae.InnerException.InnerException.GetType().ToString().Equals("System.Net.Http.CurlException")))
+                {
+                    System.Environment.Exit(context.StayOpen ? 2 : (invokeError == null ? 0 : 1));
+                }
+                else
+                {
+                    throw ae;
+                }
+            }
+
             if (result.StatusCode != HttpStatusCode.OK)
             {
                 throw new Exception("Got a bad response from the bootstrap");
@@ -185,12 +204,12 @@ namespace AWSLambda.Internal.Bootstrap
                 }
                 catch (AggregateException ae)
                 {
-                    if (!context.StayOpen && ae.InnerException is HttpRequestException && ae.InnerException.InnerException != null &&
+                    if (ae.InnerException is HttpRequestException && ae.InnerException.InnerException != null &&
                         (ae.InnerException.InnerException is SocketException ||
                             // happens on dotnetcore2.0
                             ae.InnerException.InnerException.GetType().ToString().Equals("System.Net.Http.CurlException")))
                     {
-                        System.Environment.Exit(string.IsNullOrEmpty(errorType) && invokeError == null ? 0 : 1);
+                        System.Environment.Exit(context.StayOpen ? 2 : (string.IsNullOrEmpty(errorType) && invokeError == null ? 0 : 1));
                     }
                     else
                     {

--- a/java8/run/lambda-runtime-mock/src/main/java/lambdainternal/LambdaRuntime.java
+++ b/java8/run/lambda-runtime-mock/src/main/java/lambdainternal/LambdaRuntime.java
@@ -23,7 +23,6 @@ import com.google.gson.Gson;
 
 import sun.misc.Unsafe;
 import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 @SuppressWarnings("restriction")
 public class LambdaRuntime {
@@ -101,7 +100,7 @@ public class LambdaRuntime {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        
+
         Signal.handle(new Signal("HUP"), (Signal signal) -> {
           if (STAY_OPEN) {
               systemErr("SIGHUP received, exiting runtime...");

--- a/nodejs4.3/run/awslambda-mock.js
+++ b/nodejs4.3/run/awslambda-mock.js
@@ -34,6 +34,10 @@ var DEADLINE_MS = Date.now() + (TIMEOUT * 1000)
 
 process.on('SIGINT', () => process.exit(0))
 process.on('SIGTERM', () => process.exit(0))
+process.on('SIGHUP', () => {
+  systemErr("SIGHUP received, exiting runtime...")
+  process.exit(2)
+})
 
 // Don't think this can be done in the Docker image
 process.umask(2)
@@ -134,7 +138,7 @@ module.exports = {
           })
       }).on('error', err => {
         if (err.code === 'ECONNRESET') {
-          return process.exit(errored ? 1 : 0)
+          return process.exit(STAY_OPEN ? 2 : (errored ? 1 : 0))
         }
         console.error(err)
         process.exit(1)

--- a/nodejs6.10/run/awslambda-mock.js
+++ b/nodejs6.10/run/awslambda-mock.js
@@ -34,6 +34,10 @@ var DEADLINE_MS = Date.now() + (TIMEOUT * 1000)
 
 process.on('SIGINT', () => process.exit(0))
 process.on('SIGTERM', () => process.exit(0))
+process.on('SIGHUP', () => {
+  systemErr("SIGHUP received, exiting runtime...")
+  process.exit(2)
+})
 
 // Don't think this can be done in the Docker image
 process.umask(2)
@@ -134,7 +138,7 @@ module.exports = {
           })
       }).on('error', err => {
         if (err.code === 'ECONNRESET') {
-          return process.exit(errored ? 1 : 0)
+          return process.exit(STAY_OPEN ? 2 : (errored ? 1 : 0))
         }
         console.error(err)
         process.exit(1)

--- a/nodejs8.10/run/awslambda-mock.js
+++ b/nodejs8.10/run/awslambda-mock.js
@@ -34,6 +34,10 @@ var DEADLINE_MS = Date.now() + (TIMEOUT * 1000)
 
 process.on('SIGINT', () => process.exit(0))
 process.on('SIGTERM', () => process.exit(0))
+process.on('SIGHUP', () => {
+  systemErr("SIGHUP received, exiting runtime...")
+  process.exit(2)
+})
 
 // Don't think this can be done in the Docker image
 process.umask(2)
@@ -135,7 +139,7 @@ module.exports = {
           })
       }).on('error', err => {
         if (err.code === 'ECONNRESET') {
-          return process.exit(errored ? 1 : 0)
+          return process.exit(STAY_OPEN ? 2 : (errored ? 1 : 0))
         }
         console.error(err)
         process.exit(1)

--- a/provided/run/go.mod
+++ b/provided/run/go.mod
@@ -3,6 +3,7 @@ module init
 require (
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-chi/render v1.0.1
+	github.com/rjeczalik/notify v0.9.2
 )
 
 go 1.13

--- a/provided/run/go.sum
+++ b/provided/run/go.sum
@@ -2,3 +2,7 @@ github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAU
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
+github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
+github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7 h1:bit1t3mgdR35yN0cX0G8orgLtOuyL9Wqxa1mccLB0ig=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Addresses #229 

Can either send SIGHUP to the bootstrap process:
```sh
docker kill --signal=SIGHUP <container_id>
```

Or, if you pass `DOCKER_LAMBDA_WATCH=1` as an env var, then any changes to files in `/var/task` or `/opt` (ie, your handler directory and any layers you have mounted) will trigger the bootstrap to be killed (and it will cold start again on next invocation)

```
docker run --rm -v "$PWD":/var/task:ro,delegated \
  -e DOCKER_LAMBDA_STAY_OPEN=1 \
  -e DOCKER_LAMBDA_WATCH=1 \
  -p 9001:9001 \
  lambci/lambda:provided handler
```

Works with the following runtimes: `provided`, `nodejs10.x`, `nodejs12.x`, `python3.7`, `python3.8` `ruby2.5`, `java11`

The other runtimes will need another strategy that restarts the root process (the easiest will be to utilize `docker run --restart on-failure` and then having the runtimes error if the bootstrap exits)