### PR TITLE
Set bundler to a specific version that matches what is in AWS

### DIFF
--- a/ruby2.5/build/Dockerfile
+++ b/ruby2.5/build/Dockerfile
@@ -12,5 +12,5 @@ RUN rm -rf /var/runtime /var/lang /var/rapid && \
 
 # Add these as a separate layer as they get updated frequently
 RUN gem update --system --no-document && \
-  gem install --no-document bundler && \
+  gem install --no-document bundler -v 2.0.2 && \
   pip install -U awscli boto3 aws-sam-cli==0.39.0 aws-lambda-builders==0.6.0 --no-cache-dir

--- a/ruby2.5/build/Dockerfile
+++ b/ruby2.5/build/Dockerfile
@@ -12,5 +12,5 @@ RUN rm -rf /var/runtime /var/lang /var/rapid && \
 
 # Add these as a separate layer as they get updated frequently
 RUN gem update --system --no-document && \
-  gem install --no-document bundler -v 2.0.2 && \
+  gem install --no-document bundler -v '~> 2.1' && \
   pip install -U awscli boto3 aws-sam-cli==0.39.0 aws-lambda-builders==0.6.0 --no-cache-dir


### PR DESCRIPTION
Currently the latest version of `bundler` will be installed into the docker image upon any build, causing bundler to get out of sync with the lambda environment.

Version `2.0.2` was determined based on the output of the following (very basic) lambda code:

```
require 'json'
require 'bundler'

def lambda_handler(event:, context:)
    # TODO implement
    puts "#{Bundler::VERSION}"
    { statusCode: 200, body: JSON.generate('Hello from Lambda!') }
end
```

