### PR TITLE
set BUNDLE_SILENCE_ROOT_WARNING=1 for all ruby container

### DIFF
--- a/ruby2.5/build/Dockerfile
+++ b/ruby2.5/build/Dockerfile
@@ -5,7 +5,8 @@ ENV PATH=/var/lang/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_ruby2.5 \
     GEM_HOME=/var/runtime \
     GEM_PATH=/var/task/vendor/bundle/ruby/2.5.0:/opt/ruby/gems/2.5.0:/var/lang/lib/ruby/gems/2.5.0 \
-    RUBYLIB=/var/task:/var/runtime/lib:/opt/ruby/lib
+    RUBYLIB=/var/task:/var/runtime/lib:/opt/ruby/lib \
+    BUNDLE_SILENCE_ROOT_WARNING=1
 
 RUN rm -rf /var/runtime /var/lang /var/rapid && \
   curl https://lambci.s3.amazonaws.com/fs/ruby2.5.tgz | tar -zx -C /

--- a/ruby2.7/build/Dockerfile
+++ b/ruby2.7/build/Dockerfile
@@ -5,7 +5,8 @@ ENV PATH=/var/lang/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_ruby2.7 \
     GEM_HOME=/var/runtime \
     GEM_PATH=/var/task/vendor/bundle/ruby/2.7.0:/opt/ruby/gems/2.7.0:/var/lang/lib/ruby/gems/2.7.0 \
-    RUBYLIB=/var/task:/var/runtime/lib:/opt/ruby/lib
+    RUBYLIB=/var/task:/var/runtime/lib:/opt/ruby/lib \
+    BUNDLE_SILENCE_ROOT_WARNING=1
 
 RUN rm -rf /var/runtime /var/lang /var/rapid && \
   curl https://lambci.s3.amazonaws.com/fs/ruby2.7.tgz | tar -zx -C /


### PR DESCRIPTION
This change suppress the "Don't run Bundler as root" warning, this config it's used by the official [ruby dockerfile as well](https://github.com/docker-library/ruby/blob/master/2.5/alpine3.11/Dockerfile#L127).
```
Don't run Bundler as root. Bundler can ask for sudo if it is needed,
and installing your bundle as root will break this application for all non-root users on this machine.
```