### PR TITLE
fix: Don't set default values for ACCESS_KEY_ID and SECRET_ACCESS_KEY

### DIFF
--- a/java8/run/lambda-runtime-mock/src/main/java/lambdainternal/LambdaRuntime.java
+++ b/java8/run/lambda-runtime-mock/src/main/java/lambdainternal/LambdaRuntime.java
@@ -72,8 +72,8 @@ public class LambdaRuntime {
         FUNCTION_VERSION = getEnvOrDefault("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST");
         LOG_GROUP_NAME = getEnvOrDefault("AWS_LAMBDA_LOG_GROUP_NAME", "/aws/lambda/" + FUNCTION_NAME);
         LOG_STREAM_NAME = getEnvOrDefault("AWS_LAMBDA_LOG_STREAM_NAME", randomLogStreamName(FUNCTION_VERSION));
-        AWS_ACCESS_KEY_ID = getEnvOrDefault("AWS_ACCESS_KEY_ID", "SOME_ACCESS_KEY_ID");
-        AWS_SECRET_ACCESS_KEY = getEnvOrDefault("AWS_SECRET_ACCESS_KEY", "SOME_SECRET_ACCESS_KEY");
+        AWS_ACCESS_KEY_ID = getEnvOrDefault("AWS_ACCESS_KEY_ID","");
+        AWS_SECRET_ACCESS_KEY = getEnvOrDefault("AWS_SECRET_ACCESS_KEY","");
         AWS_SESSION_TOKEN = getEnv("AWS_SESSION_TOKEN");
         AWS_REGION = getEnvOrDefault("AWS_REGION", getEnvOrDefault("AWS_DEFAULT_REGION", "us-east-1"));
 


### PR DESCRIPTION
Set them to blank in case nulls are not allowed.
This breaks the default AWS credentials provider. I tried to use profile credentials from ~/aws/.credentials but it's impossible now as the chain picks up those mock defaults instead.
Setting the envs to blank in container doesn't help as I see the mock values are still somehow set.

```
docker run  -v "$HOME/.aws/credentials:/home/sbx_user1051/.aws/credentials:ro,delegated"  ...
```