### PR TITLE
fix(log): apply billed duration by 1ms

### DIFF
--- a/provided/run/init.go
+++ b/provided/run/init.go
@@ -978,7 +978,7 @@ func (mc *mockLambdaContext) LogEndRequest() {
 			"Billed Duration: %.f ms\t"+
 			"Memory Size: %s MB\t"+
 			"Max Memory Used: %d MB\t",
-		mc.RequestID, diffMs, math.Ceil(diffMs/100)*100, mc.MemSize, mc.MaxMem))
+		mc.RequestID, diffMs, math.Ceil(diffMs), mc.MemSize, mc.MaxMem))
 }
 
 type invokeResponse struct {


### PR DESCRIPTION
https://aws.amazon.com/ko/blogs/aws/new-for-aws-lambda-1ms-billing-granularity-adds-cost-savings/

Lambda billed duration was updated by 1ms, but I found the log was not applied yet.