### PR TITLE
feat: Add support for nodejs14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ You can also use [yumda](https://github.com/lambci/yumda) to install precompiled
 ## Run Examples
 
 ```sh
-# Test a `handler` function from an `index.js` file in the current directory on Node.js v12.x
-docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:nodejs12.x index.handler
+# Test a `handler` function from an `index.js` file in the current directory on Node.js v14.x
+docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:nodejs14.x index.handler
 
 # Using a different file and handler, with a custom event
-docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:nodejs12.x app.myHandler '{"some": "event"}'
+docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:nodejs14.x app.myHandler '{"some": "event"}'
 
 # Test a `lambda_handler` function in `lambda_function.py` with an empty event on Python 3.8
 docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:python3.8 lambda_function.lambda_handler
@@ -207,13 +207,13 @@ docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:dotnetcore3.1 tes
 docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:provided handler '{"some": "event"}'
 
 # Test with layers (assumes your function code is in `./fn` and your layers in `./layer`)
-docker run --rm -v "$PWD"/fn:/var/task:ro,delegated -v "$PWD"/layer:/opt:ro,delegated lambci/lambda:nodejs12.x
+docker run --rm -v "$PWD"/fn:/var/task:ro,delegated -v "$PWD"/layer:/opt:ro,delegated lambci/lambda:nodejs14.x
 
 # Run custom commands
-docker run --rm --entrypoint node lambci/lambda:nodejs12.x -v
+docker run --rm --entrypoint node lambci/lambda:nodejs14.x -v
 
 # For large events you can pipe them into stdin if you set DOCKER_LAMBDA_USE_STDIN
-echo '{"some": "event"}' | docker run --rm -v "$PWD":/var/task:ro,delegated -i -e DOCKER_LAMBDA_USE_STDIN=1 lambci/lambda:nodejs12.x
+echo '{"some": "event"}' | docker run --rm -v "$PWD":/var/task:ro,delegated -i -e DOCKER_LAMBDA_USE_STDIN=1 lambci/lambda:nodejs14.x
 ```
 
 You can see more examples of how to build docker images and run different
@@ -225,7 +225,7 @@ To use the build images, for compilation, deployment, etc:
 
 ```sh
 # To compile native deps in node_modules
-docker run --rm -v "$PWD":/var/task lambci/lambda:build-nodejs12.x npm rebuild --build-from-source
+docker run --rm -v "$PWD":/var/task lambci/lambda:build-nodejs14.x npm rebuild --build-from-source
 
 # To install defined poetry dependencies
 docker run --rm -v "$PWD":/var/task lambci/lambda:build-python3.8 poetry install
@@ -249,7 +249,7 @@ docker run -it lambci/lambda:build-python3.8 bash
 Create your own Docker image to build and deploy:
 
 ```dockerfile
-FROM lambci/lambda:build-nodejs12.x
+FROM lambci/lambda:build-nodejs14.x
 
 ENV AWS_DEFAULT_REGION us-east-1
 
@@ -277,10 +277,10 @@ Using the Node.js module (`npm install docker-lambda`) – for example in tests:
 var dockerLambda = require('docker-lambda')
 
 // Spawns synchronously, uses current dir – will throw if it fails
-var lambdaCallbackResult = dockerLambda({event: {some: 'event'}, dockerImage: 'lambci/lambda:nodejs12.x'})
+var lambdaCallbackResult = dockerLambda({event: {some: 'event'}, dockerImage: 'lambci/lambda:nodejs14.x'})
 
 // Manually specify directory and custom args
-lambdaCallbackResult = dockerLambda({taskDir: __dirname, dockerArgs: ['-m', '1.5G'], dockerImage: 'lambci/lambda:nodejs12.x'})
+lambdaCallbackResult = dockerLambda({taskDir: __dirname, dockerArgs: ['-m', '1.5G'], dockerImage: 'lambci/lambda:nodejs14.x'})
 ```
 
 Options to pass to `dockerLambda()`:
@@ -303,6 +303,7 @@ These follow the Lambda runtime names:
   - `nodejs8.10`
   - `nodejs10.x`
   - `nodejs12.x`
+  - `nodejs14.x`
   - `python2.7`
   - `python3.6`
   - `python3.7`
@@ -323,6 +324,7 @@ These follow the Lambda runtime names:
   - `build-nodejs8.10`
   - `build-nodejs10.x`
   - `build-nodejs12.x`
+  - `build-nodejs14.x`
   - `build-python2.7`
   - `build-python3.6`
   - `build-python3.7`

--- a/base/dump-node14x.js
+++ b/base/dump-node14x.js
@@ -1,0 +1,38 @@
+const fs = require('fs')
+const { execSync } = require('child_process')
+const AWS = require('aws-sdk')
+const s3 = new AWS.S3()
+
+// Depends on tar-find-layer for the tar/find/xargs binaries
+exports.handler = async(event, context) => {
+  const execOpts = { stdio: 'inherit', maxBuffer: 16 * 1024 * 1024 }
+
+  let filename = 'nodejs14.x.tgz'
+  let cmd = 'tar -cpzf /tmp/' + filename +
+    ' --numeric-owner --ignore-failed-read /var/runtime /var/lang /var/rapid'
+
+  execSync(cmd, execOpts)
+
+  console.log('Zipping done! Uploading...')
+
+  let data = await s3.upload({
+    Bucket: 'lambci',
+    Key: 'fs/' + filename,
+    Body: fs.createReadStream('/tmp/' + filename),
+    ACL: 'public-read',
+  }).promise()
+
+  console.log('Uploading done!')
+
+  console.log(process.execPath)
+  console.log(process.execArgv)
+  console.log(process.argv)
+  console.log(process.cwd())
+  console.log(__filename)
+  console.log(process.env)
+  execSync('echo /proc/1/environ; xargs -n 1 -0 < /proc/1/environ', execOpts)
+  execSync("bash -O extglob -c 'for cmd in /proc/+([0-9])/cmdline; do echo $cmd; xargs -n 1 -0 < $cmd; done'", execOpts)
+  console.log(context)
+
+  return data
+}

--- a/base/runtimes.sh
+++ b/base/runtimes.sh
@@ -1,1 +1,1 @@
-RUNTIMES="provided go1.x nodejs4.3 nodejs6.10 nodejs8.10 python2.7 python3.6 python3.7 ruby2.5 java8 dotnetcore2.0 dotnetcore2.1 provided.al2 nodejs10.x nodejs12.x python3.8 ruby2.7 java8.al2 java11 dotnetcore3.1"
+RUNTIMES="provided go1.x nodejs4.3 nodejs6.10 nodejs8.10 python2.7 python3.6 python3.7 ruby2.5 java8 dotnetcore2.0 dotnetcore2.1 provided.al2 nodejs10.x nodejs12.x nodejs14.x python3.8 ruby2.7 java8.al2 java11 dotnetcore3.1"

--- a/base/test-all.sh
+++ b/base/test-all.sh
@@ -11,6 +11,7 @@ cd ${EXAMPLES_DIR}/nodejs8.10
 docker run --rm -v "$PWD":/var/task lambci/lambda:nodejs8.10
 docker run --rm -v "$PWD":/var/task lambci/lambda:nodejs10.x index.handler
 docker run --rm -v "$PWD":/var/task lambci/lambda:nodejs12.x index.handler
+docker run --rm -v "$PWD":/var/task lambci/lambda:nodejs14.x index.handler
 
 cd ${EXAMPLES_DIR}/nodejs-native-module
 npm install

--- a/nodejs14.x/build/Dockerfile
+++ b/nodejs14.x/build/Dockerfile
@@ -1,0 +1,17 @@
+FROM lambci/lambda:nodejs14.x
+
+FROM lambci/lambda-base-2:build
+
+ENV PATH=/var/lang/bin:$PATH \
+LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+AWS_EXECUTION_ENV=AWS_Lambda_nodejs14.x \
+NODE_PATH=/opt/nodejs/node14/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
+
+COPY --from=0 /var/runtime /var/runtime
+COPY --from=0 /var/lang /var/lang
+COPY --from=0 /var/rapid /var/rapid
+
+# Add these as a separate layer as they get updated frequently
+RUN pipx install awscli==1.* && \
+pipx install aws-lambda-builders==1.2.0 && \
+pipx install aws-sam-cli==1.15.0

--- a/nodejs14.x/run/Dockerfile
+++ b/nodejs14.x/run/Dockerfile
@@ -1,0 +1,21 @@
+FROM lambci/lambda-base
+
+RUN curl https://lambci.s3.amazonaws.com/fs/nodejs14.x.tgz | tar -zx -C /opt
+
+
+FROM lambci/lambda:provided
+
+
+FROM lambci/lambda-base-2
+
+ENV PATH=/var/lang/bin:$PATH \
+LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+AWS_EXECUTION_ENV=AWS_Lambda_nodejs14.x
+
+COPY --from=0 /opt/* /var/
+
+COPY --from=1 /var/runtime/init /var/rapid/init
+
+USER sbx_user1051
+
+ENTRYPOINT ["/var/rapid/init", "--bootstrap", "/var/runtime/bootstrap", "--enable-msg-logs"]


### PR DESCRIPTION
This is an attempt to add support for `nodejs14.x` runtime. I believe it needs manual action from someone with proper privileges to actually build the base image - it also needs a bit more testing - currently, it follows a similar approach that was used when adding support for `nodejs12.x`. 

I'd love to hear feedback, what is additionally needed and how I can help to get support for `nodejs14.x` through the finish line/

Thanks in advance

cc @mhart 

Closes: #329 