### PR TITLE
Bump golang image to 1.6

### DIFF
--- a/base/dump-go1x/go.mod
+++ b/base/dump-go1x/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.17.0
 )
 
-go 1.15
+go 1.16

--- a/base/dump-providedal2/go.mod
+++ b/base/dump-providedal2/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 )
 
-go 1.15
+go 1.16

--- a/examples/go1.x/go.mod
+++ b/examples/go1.x/go.mod
@@ -2,4 +2,4 @@ module handler
 
 require github.com/aws/aws-lambda-go v1.13.3
 
-go 1.15
+go 1.16

--- a/examples/provided.al2/go.mod
+++ b/examples/provided.al2/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 )
 
-go 1.15
+go 1.16

--- a/go1.x/build/Dockerfile
+++ b/go1.x/build/Dockerfile
@@ -3,7 +3,7 @@ FROM lambci/lambda:go1.x
 FROM lambci/lambda-base:build
 
 # https://golang.org/doc/devel/release.html
-ENV GOLANG_VERSION=1.15 \
+ENV GOLANG_VERSION=1.16 \
     GOPATH=/go \
     PATH=/go/bin:/usr/local/go/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_go1.x

--- a/go1.x/run/go.mod
+++ b/go1.x/run/go.mod
@@ -2,4 +2,4 @@ module aws-lambda-mock
 
 require github.com/aws/aws-lambda-go v1.13.3
 
-go 1.15
+go 1.16

--- a/provided/run/go.mod
+++ b/provided/run/go.mod
@@ -6,4 +6,4 @@ require (
 	github.com/rjeczalik/notify v0.9.2
 )
 
-go 1.15
+go 1.16


### PR DESCRIPTION
Hello. First of all, thank you for creating this amazing docker image.
I'm using this image in my project. I created this PR because I noticed one improvement.

## Summary

The latest stable version of golang today is 1.6.
However, the supported version for this repository is 1.5.
I want to use 1.6, so I upgraded it.

Can you check the contents of my commit?