### PR TITLE
feat: Add python3.9 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:nodejs12.x app.my
 # Test a `lambda_handler` function in `lambda_function.py` with an empty event on Python 3.8
 docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:python3.8 lambda_function.lambda_handler
 
+# Test a `lambda_handler` function in `lambda_function.py` with an empty event on Python 3.9
+docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:python3.9 lambda_function.lambda_handler
+
 # Similarly with Ruby 2.7
 docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:ruby2.7 lambda_function.lambda_handler
 
@@ -230,6 +233,9 @@ docker run --rm -v "$PWD":/var/task lambci/lambda:build-nodejs12.x npm rebuild -
 # To install defined poetry dependencies
 docker run --rm -v "$PWD":/var/task lambci/lambda:build-python3.8 poetry install
 
+# To install defined poetry dependencies
+docker run --rm -v "$PWD":/var/task lambci/lambda:build-python3.9 poetry install
+
 # To resolve dependencies on go1.x (working directory is /go/src/handler)
 docker run --rm -v "$PWD":/go/src/handler lambci/lambda:build-go1.x go mod download
 
@@ -242,6 +248,12 @@ docker run --rm lambci/lambda:build-python3.8 aws --version
 
 # To run an interactive session on a build container
 docker run -it lambci/lambda:build-python3.8 bash
+
+# Run custom commands on a build container
+docker run --rm lambci/lambda:build-python3.9 aws --version
+
+# To run an interactive session on a build container
+docker run -it lambci/lambda:build-python3.9 bash
 ```
 
 ## Using a Dockerfile to build
@@ -307,6 +319,7 @@ These follow the Lambda runtime names:
   - `python3.6`
   - `python3.7`
   - `python3.8`
+  - `python3.9`
   - `ruby2.5`
   - `ruby2.7`
   - `java8`
@@ -327,6 +340,7 @@ These follow the Lambda runtime names:
   - `build-python3.6`
   - `build-python3.7`
   - `build-python3.8`
+  - `build-python3.9`
   - `build-ruby2.5`
   - `build-ruby2.7`
   - `build-java8`

--- a/base/dump-python39.py
+++ b/base/dump-python39.py
@@ -1,0 +1,69 @@
+from __future__ import print_function
+
+import os
+import sys
+import subprocess
+import json
+import boto3
+from boto3.s3.transfer import S3Transfer
+
+TRANSFER = S3Transfer(boto3.client("s3"))
+
+
+def lambda_handler(event, context):
+    if "cmd" in event:
+        return print(
+            subprocess.check_output(["sh", "-c", event["cmd"]]).decode("utf-8")
+        )
+
+    filename = "python3.9.tgz"
+
+    subprocess.call(
+        [
+            "sh",
+            "-c",
+            f"tar -cpzf /tmp/{filename} --numeric-owner --ignore-failed-read "
+            + "/var/runtime /var/lang /var/rapid",
+        ]
+    )
+
+    print("Zipping done! Uploading...")
+
+    TRANSFER.upload_file(
+        f"/tmp/{filename}",
+        "lambci",
+        f"fs/{filename}",
+        extra_args={"ACL": "public-read"},
+    )
+
+    print("Uploading done!")
+
+    info = {
+        "sys.executable": sys.executable,
+        "sys.argv": sys.argv,
+        "sys.path": sys.path,
+        "os.getcwd": os.getcwd(),
+        "__file__": __file__,
+        "os.environ": {k: str(v) for k, v in os.environ.items()},
+        "context": {k: str(v) for k, v in context.__dict__.items()},
+        "proc environ": subprocess.check_output(
+            ["sh", "-c", "echo /proc/1/environ; xargs -n 1 -0 < /proc/1/environ"]
+        )
+        .decode("utf-8")
+        .splitlines(),
+        "ps aux": subprocess.check_output(
+            [
+                "bash",
+                "-O",
+                "extglob",
+                "-c",
+                "for cmd in /proc/+([0-9])/cmdline; do echo $cmd; xargs -n 1 -0 < $cmd; done",
+            ]
+        )
+        .decode("utf-8")
+        .splitlines(),
+    }
+
+    print(json.dumps(info, indent=2))
+
+    return info

--- a/base/runtimes.sh
+++ b/base/runtimes.sh
@@ -1,1 +1,1 @@
-RUNTIMES="provided go1.x nodejs4.3 nodejs6.10 nodejs8.10 python2.7 python3.6 python3.7 ruby2.5 java8 dotnetcore2.0 dotnetcore2.1 provided.al2 nodejs10.x nodejs12.x python3.8 ruby2.7 java8.al2 java11 dotnetcore3.1"
+RUNTIMES="provided go1.x nodejs4.3 nodejs6.10 nodejs8.10 python2.7 python3.6 python3.7 ruby2.5 java8 dotnetcore2.0 dotnetcore2.1 provided.al2 nodejs10.x nodejs12.x python3.8 ruby2.7 java8.al2 java11 dotnetcore3.1 python3.9"

--- a/base/test-all.sh
+++ b/base/test-all.sh
@@ -22,12 +22,14 @@ docker run --rm -v "$PWD":/var/task lambci/lambda:python2.7
 docker run --rm -v "$PWD":/var/task lambci/lambda:python3.6
 docker run --rm -v "$PWD":/var/task lambci/lambda:python3.7 lambda_function.lambda_handler
 docker run --rm -v "$PWD":/var/task lambci/lambda:python3.8 lambda_function.lambda_handler
+docker run --rm -v "$PWD":/var/task lambci/lambda:python3.9 lambda_function.lambda_handler
 
 cd ${EXAMPLES_DIR}/python
 docker run --rm -it lambci/lambda:build-python2.7 pip install marisa-trie
 docker run --rm -it lambci/lambda:build-python3.6 pip install marisa-trie
 docker run --rm -it lambci/lambda:build-python3.7 pip install marisa-trie
 docker run --rm -it lambci/lambda:build-python3.8 pip install marisa-trie
+docker run --rm -it lambci/lambda:build-python3.9 pip install marisa-trie
 
 cd ${EXAMPLES_DIR}/ruby
 docker run --rm -v "$PWD":/var/task lambci/lambda:ruby2.5 lambda_function.lambda_handler

--- a/python3.9/build/Dockerfile
+++ b/python3.9/build/Dockerfile
@@ -1,0 +1,24 @@
+FROM lambci/lambda:python3.9
+
+FROM lambci/lambda-base-2:build
+
+ENV PATH=/var/lang/bin:$PATH \
+    LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+    AWS_EXECUTION_ENV=AWS_Lambda_python3.9 \
+    PKG_CONFIG_PATH=/var/lang/lib/pkgconfig:/usr/lib64/pkgconfig:/usr/share/pkgconfig \
+    PIPX_BIN_DIR=/var/lang/bin \
+    PIPX_HOME=/var/lang/pipx
+
+COPY --from=0 /var/runtime /var/runtime
+COPY --from=0 /var/lang /var/lang
+COPY --from=0 /var/rapid /var/rapid
+
+# Add these as a separate layer as they get updated frequently
+RUN pip install -U pip setuptools wheel --no-cache-dir && \
+  pip install pipx --no-cache-dir && \
+  pipx install virtualenv && \
+  pipx install pipenv && \
+  pipx install poetry==1.1.4 && \
+  pipx install awscli==1.* && \
+  pipx install aws-lambda-builders==1.2.0 && \
+  pipx install aws-sam-cli==1.15.0

--- a/python3.9/run/Dockerfile
+++ b/python3.9/run/Dockerfile
@@ -1,0 +1,22 @@
+FROM lambci/lambda-base
+
+RUN curl https://lambci.s3.amazonaws.com/fs/python3.9.tgz | tar -zx -C /opt
+
+
+FROM lambci/lambda:provided
+
+
+FROM lambci/lambda-base-2
+
+ENV PATH=/var/lang/bin:$PATH \
+    LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+    AWS_EXECUTION_ENV=AWS_Lambda_python3.9
+
+COPY --from=0 /opt/* /var/
+
+COPY --from=1 /var/runtime/init /var/rapid/init
+
+USER sbx_user1051
+
+ENTRYPOINT ["/var/rapid/init", "--bootstrap", "/var/runtime/bootstrap", "--enable-msg-logs"]
+


### PR DESCRIPTION
Now that amazon added support for Python 3.9 it would be great to add Python 3.9 support
https://aws.amazon.com/tw/about-aws/whats-new/2021/08/aws-lambda-adds-support-python-3-9/

This is an attempt to mimic:
https://github.com/lambci/docker-lambda/commit/a94337ae2410a94a9ac878622eb82b26bc385a92#diff-0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505

But this has a dependency on: https://github.com/lambci/lambci/issues/138
