### PR TITLE
Golang update to 1.17 in builder Dockerfile

### DIFF
--- a/base/dump-go1x/go.mod
+++ b/base/dump-go1x/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.17.0
 )
 
-go 1.15
+go 1.17

--- a/base/dump-providedal2/go.mod
+++ b/base/dump-providedal2/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 )
 
-go 1.15
+go 1.17

--- a/examples/go1.x/go.mod
+++ b/examples/go1.x/go.mod
@@ -2,4 +2,4 @@ module handler
 
 require github.com/aws/aws-lambda-go v1.13.3
 
-go 1.15
+go 1.17

--- a/examples/provided.al2/go.mod
+++ b/examples/provided.al2/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 )
 
-go 1.15
+go 1.17

--- a/go1.x/build/Dockerfile
+++ b/go1.x/build/Dockerfile
@@ -3,7 +3,7 @@ FROM lambci/lambda:go1.x
 FROM lambci/lambda-base:build
 
 # https://golang.org/doc/devel/release.html
-ENV GOLANG_VERSION=1.15 \
+ENV GOLANG_VERSION=1.17 \
     GOPATH=/go \
     PATH=/go/bin:/usr/local/go/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_go1.x
@@ -14,10 +14,7 @@ COPY --from=0 /var/runtime /var/runtime
 COPY --from=0 /var/lang /var/lang
 COPY --from=0 /var/rapid /var/rapid
 
-RUN curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar -zx -C /usr/local && \
-  go get github.com/golang/dep/cmd/dep && \
-  go install github.com/golang/dep/cmd/dep && \
-  go get golang.org/x/vgo
+RUN curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar -zx -C /usr/local
 
 # Add these as a separate layer as they get updated frequently
 # The pipx workaround is due to https://github.com/pipxproject/pipx/issues/218

--- a/go1.x/run/go.mod
+++ b/go1.x/run/go.mod
@@ -2,4 +2,4 @@ module aws-lambda-mock
 
 require github.com/aws/aws-lambda-go v1.13.3
 
-go 1.15
+go 1.17

--- a/provided/run/go.mod
+++ b/provided/run/go.mod
@@ -6,4 +6,4 @@ require (
 	github.com/rjeczalik/notify v0.9.2
 )
 
-go 1.15
+go 1.17


### PR DESCRIPTION
This pull request bumps up the Golang version from 1.15 to latest 1.17 for lambci/lambda:build-go1.x.

- remove the `dep`, [reason](https://github.com/golang/go/issues/38158)

```
docker build -t lambci/lambda:build-go1.x .
docker run -it --rm lambci/lambda:build-go1.x  go version
```

#345